### PR TITLE
feat: implement academic management api

### DIFF
--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -1,3 +1,7 @@
 import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as schema from "./schema/app-schema";
+import * as authSchema from "./schema/auth";
 
-export const db = drizzle(process.env.DATABASE_URL || "");
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const db = drizzle(pool, { schema: { ...schema, ...authSchema } });

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -23,5 +23,8 @@ export const auth = betterAuth({
 			secure: true,
 			httpOnly: true,
 		},
-	},
+        },
 });
+
+export const adminRoles = ["ADMIN", "SUPER_ADMIN"] as const;
+export const superAdminRoles = ["SUPER_ADMIN"] as const;

--- a/apps/server/src/repositories/academicYears.repo.ts
+++ b/apps/server/src/repositories/academicYears.repo.ts
@@ -1,0 +1,37 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewAcademicYear) {
+  const [item] = await db.insert(schema.academicYears).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewAcademicYear>) {
+  const [item] = await db
+    .update(schema.academicYears)
+    .set(data)
+    .where(eq(schema.academicYears.id, id))
+    .returning();
+  return item;
+}
+
+export async function findById(id: string) {
+  return db.query.academicYears.findFirst({ where: eq(schema.academicYears.id, id) });
+}
+
+export async function list(opts: { cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.cursor) {
+    condition = gt(schema.academicYears.id, opts.cursor);
+  }
+  const items = await db
+    .select()
+    .from(schema.academicYears)
+    .where(condition)
+    .orderBy(schema.academicYears.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}

--- a/apps/server/src/repositories/classCourses.repo.ts
+++ b/apps/server/src/repositories/classCourses.repo.ts
@@ -1,0 +1,53 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, and, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewClassCourse) {
+  const [item] = await db.insert(schema.classCourses).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewClassCourse>) {
+  const [item] = await db
+    .update(schema.classCourses)
+    .set(data)
+    .where(eq(schema.classCourses.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.classCourses).where(eq(schema.classCourses.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.classCourses.findFirst({ where: eq(schema.classCourses.id, id) });
+}
+
+export async function list(opts: { classId?: string; courseId?: string; teacherId?: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.classId) {
+    condition = eq(schema.classCourses.class, opts.classId);
+  }
+  if (opts.courseId) {
+    const cc = eq(schema.classCourses.course, opts.courseId);
+    condition = condition ? and(condition, cc) : cc;
+  }
+  if (opts.teacherId) {
+    const tc = eq(schema.classCourses.teacher, opts.teacherId);
+    condition = condition ? and(condition, tc) : tc;
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.classCourses.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.classCourses)
+    .where(condition)
+    .orderBy(schema.classCourses.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}

--- a/apps/server/src/repositories/classes.repo.ts
+++ b/apps/server/src/repositories/classes.repo.ts
@@ -1,0 +1,49 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, and, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewKlass) {
+  const [item] = await db.insert(schema.classes).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewKlass>) {
+  const [item] = await db
+    .update(schema.classes)
+    .set(data)
+    .where(eq(schema.classes.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.classes).where(eq(schema.classes.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.classes.findFirst({ where: eq(schema.classes.id, id) });
+}
+
+export async function list(opts: { programId?: string; academicYearId?: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.programId) {
+    condition = eq(schema.classes.program, opts.programId);
+  }
+  if (opts.academicYearId) {
+    const ay = eq(schema.classes.academicYear, opts.academicYearId);
+    condition = condition ? and(condition, ay) : ay;
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.classes.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.classes)
+    .where(condition)
+    .orderBy(schema.classes.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}

--- a/apps/server/src/repositories/courses.repo.ts
+++ b/apps/server/src/repositories/courses.repo.ts
@@ -1,0 +1,54 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, and, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewCourse) {
+  const [item] = await db.insert(schema.courses).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewCourse>) {
+  const [item] = await db
+    .update(schema.courses)
+    .set(data)
+    .where(eq(schema.courses.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.courses).where(eq(schema.courses.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.courses.findFirst({ where: eq(schema.courses.id, id) });
+}
+
+export async function list(opts: { programId?: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.programId) {
+    condition = eq(schema.courses.program, opts.programId);
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.courses.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.courses)
+    .where(condition)
+    .orderBy(schema.courses.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function assignDefaultTeacher(courseId: string, teacherId: string) {
+  const [item] = await db
+    .update(schema.courses)
+    .set({ defaultTeacher: teacherId })
+    .where(eq(schema.courses.id, courseId))
+    .returning();
+  return item;
+}

--- a/apps/server/src/repositories/exams.repo.ts
+++ b/apps/server/src/repositories/exams.repo.ts
@@ -1,0 +1,62 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, and, gt, gte, lte } from "drizzle-orm";
+
+export async function create(data: schema.NewExam) {
+  const [item] = await db.insert(schema.exams).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewExam>) {
+  const [item] = await db
+    .update(schema.exams)
+    .set(data)
+    .where(eq(schema.exams.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.exams).where(eq(schema.exams.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.exams.findFirst({ where: eq(schema.exams.id, id) });
+}
+
+export async function list(opts: { classCourseId?: string; dateFrom?: Date; dateTo?: Date; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.classCourseId) {
+    condition = eq(schema.exams.classCourse, opts.classCourseId);
+  }
+  if (opts.dateFrom) {
+    const c = gte(schema.exams.date, opts.dateFrom);
+    condition = condition ? and(condition, c) : c;
+  }
+  if (opts.dateTo) {
+    const c = lte(schema.exams.date, opts.dateTo);
+    condition = condition ? and(condition, c) : c;
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.exams.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.exams)
+    .where(condition)
+    .orderBy(schema.exams.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function setLock(examId: string, lock: boolean) {
+  const [item] = await db
+    .update(schema.exams)
+    .set({ isLocked: lock })
+    .where(eq(schema.exams.id, examId))
+    .returning();
+  return item;
+}

--- a/apps/server/src/repositories/faculties.repo.ts
+++ b/apps/server/src/repositories/faculties.repo.ts
@@ -1,0 +1,45 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, ilike, and, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewFaculty) {
+  const [item] = await db.insert(schema.faculties).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewFaculty>) {
+  const [item] = await db
+    .update(schema.faculties)
+    .set(data)
+    .where(eq(schema.faculties.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.faculties).where(eq(schema.faculties.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.faculties.findFirst({ where: eq(schema.faculties.id, id) });
+}
+
+export async function list(opts: { q?: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.q) {
+    condition = ilike(schema.faculties.name, `%${opts.q}%`);
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.faculties.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.faculties)
+    .where(condition)
+    .orderBy(schema.faculties.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}

--- a/apps/server/src/repositories/grades.repo.ts
+++ b/apps/server/src/repositories/grades.repo.ts
@@ -1,0 +1,98 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, and, gt, sql } from "drizzle-orm";
+
+export async function upsert(data: schema.NewGrade) {
+  const [item] = await db
+    .insert(schema.grades)
+    .values(data)
+    .onConflictDoUpdate({
+      target: [schema.grades.student, schema.grades.exam],
+      set: { score: data.score, updatedAt: new Date() },
+    })
+    .returning();
+  return item;
+}
+
+export async function update(id: string, score: string) {
+  const [item] = await db
+    .update(schema.grades)
+    .set({ score, updatedAt: new Date() })
+    .where(eq(schema.grades.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.grades).where(eq(schema.grades.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.grades.findFirst({ where: eq(schema.grades.id, id) });
+}
+
+export async function listByExam(opts: { examId: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  const items = await db
+    .select()
+    .from(schema.grades)
+    .where(and(eq(schema.grades.exam, opts.examId), opts.cursor ? gt(schema.grades.id, opts.cursor) : undefined))
+    .orderBy(schema.grades.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function listByStudent(opts: { studentId: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  const items = await db
+    .select()
+    .from(schema.grades)
+    .where(and(eq(schema.grades.student, opts.studentId), opts.cursor ? gt(schema.grades.id, opts.cursor) : undefined))
+    .orderBy(schema.grades.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function listByClassCourse(opts: { classCourseId: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  const rows = await db
+    .select({ grade: schema.grades })
+    .from(schema.grades)
+    .innerJoin(schema.exams, eq(schema.grades.exam, schema.exams.id))
+    .where(and(eq(schema.exams.classCourse, opts.classCourseId), opts.cursor ? gt(schema.grades.id, opts.cursor) : undefined))
+    .orderBy(schema.grades.id)
+    .limit(limit);
+  const items = rows.map((r) => r.grade);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function avgForExam(examId: string) {
+  const [row] = await db
+    .select({ avg: sql`avg(${schema.grades.score})` })
+    .from(schema.grades)
+    .where(eq(schema.grades.exam, examId));
+  return row?.avg as number | null;
+}
+
+export async function avgForCourse(courseId: string) {
+  const [row] = await db
+    .select({ avg: sql`avg(${schema.grades.score})` })
+    .from(schema.grades)
+    .innerJoin(schema.exams, eq(schema.grades.exam, schema.exams.id))
+    .innerJoin(schema.classCourses, eq(schema.exams.classCourse, schema.classCourses.id))
+    .where(eq(schema.classCourses.course, courseId));
+  return row?.avg as number | null;
+}
+
+export async function avgForStudentInCourse(studentId: string, courseId: string) {
+  const [row] = await db
+    .select({ avg: sql`avg(${schema.grades.score})` })
+    .from(schema.grades)
+    .innerJoin(schema.exams, eq(schema.grades.exam, schema.exams.id))
+    .innerJoin(schema.classCourses, eq(schema.exams.classCourse, schema.classCourses.id))
+    .where(and(eq(schema.classCourses.course, courseId), eq(schema.grades.student, studentId)));
+  return row?.avg as number | null;
+}

--- a/apps/server/src/repositories/profiles.repo.ts
+++ b/apps/server/src/repositories/profiles.repo.ts
@@ -1,0 +1,36 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, gt } from "drizzle-orm";
+
+export async function findById(id: string) {
+  return db.query.profiles.findFirst({ where: eq(schema.profiles.id, id) });
+}
+
+export async function findByEmail(email: string) {
+  return db.query.profiles.findFirst({ where: eq(schema.profiles.email, email) });
+}
+
+export async function list(opts: { cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.cursor) {
+    condition = gt(schema.profiles.id, opts.cursor);
+  }
+  const items = await db
+    .select()
+    .from(schema.profiles)
+    .where(condition)
+    .orderBy(schema.profiles.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function updateRole(id: string, role: string) {
+  const [item] = await db
+    .update(schema.profiles)
+    .set({ role })
+    .where(eq(schema.profiles.id, id))
+    .returning();
+  return item;
+}

--- a/apps/server/src/repositories/programs.repo.ts
+++ b/apps/server/src/repositories/programs.repo.ts
@@ -1,0 +1,49 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, ilike, and, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewProgram) {
+  const [item] = await db.insert(schema.programs).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewProgram>) {
+  const [item] = await db
+    .update(schema.programs)
+    .set(data)
+    .where(eq(schema.programs.id, id))
+    .returning();
+  return item;
+}
+
+export async function remove(id: string) {
+  await db.delete(schema.programs).where(eq(schema.programs.id, id));
+}
+
+export async function findById(id: string) {
+  return db.query.programs.findFirst({ where: eq(schema.programs.id, id) });
+}
+
+export async function list(opts: { facultyId?: string; q?: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.facultyId) {
+    condition = eq(schema.programs.faculty, opts.facultyId);
+  }
+  if (opts.q) {
+    const qCond = ilike(schema.programs.name, `%${opts.q}%`);
+    condition = condition ? and(condition, qCond) : qCond;
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.programs.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.programs)
+    .where(condition)
+    .orderBy(schema.programs.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}

--- a/apps/server/src/repositories/students.repo.ts
+++ b/apps/server/src/repositories/students.repo.ts
@@ -1,0 +1,54 @@
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, ilike, and, gt } from "drizzle-orm";
+
+export async function create(data: schema.NewStudent) {
+  const [item] = await db.insert(schema.students).values(data).returning();
+  return item;
+}
+
+export async function update(id: string, data: Partial<schema.NewStudent>) {
+  const [item] = await db
+    .update(schema.students)
+    .set(data)
+    .where(eq(schema.students.id, id))
+    .returning();
+  return item;
+}
+
+export async function findById(id: string) {
+  return db.query.students.findFirst({ where: eq(schema.students.id, id) });
+}
+
+export async function list(opts: { classId?: string; q?: string; cursor?: string; limit?: number }) {
+  const limit = opts.limit ?? 50;
+  let condition;
+  if (opts.classId) {
+    condition = eq(schema.students.class, opts.classId);
+  }
+  if (opts.q) {
+    const qCond = ilike(schema.students.firstName, `%${opts.q}%`);
+    condition = condition ? and(condition, qCond) : qCond;
+  }
+  if (opts.cursor) {
+    const cursorCond = gt(schema.students.id, opts.cursor);
+    condition = condition ? and(condition, cursorCond) : cursorCond;
+  }
+  const items = await db
+    .select()
+    .from(schema.students)
+    .where(condition)
+    .orderBy(schema.students.id)
+    .limit(limit);
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}
+
+export async function transferStudent(studentId: string, toClassId: string) {
+  const [item] = await db
+    .update(schema.students)
+    .set({ class: toClassId })
+    .where(eq(schema.students.id, studentId))
+    .returning();
+  return item;
+}

--- a/apps/server/src/routers/academicYears.router.ts
+++ b/apps/server/src/routers/academicYears.router.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure, superAdminProcedure } from "../lib/trpc";
+import * as service from "../services/academicYears.service";
+
+const baseSchema = z.object({ name: z.string(), startDate: z.coerce.date(), endDate: z.coerce.date() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const idSchema = z.object({ id: z.string() });
+const listSchema = z.object({ cursor: z.string().optional(), limit: z.number().optional() });
+const setActiveSchema = z.object({ id: z.string(), isActive: z.boolean() });
+
+export const academicYearsRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) =>
+    service.createAcademicYear({
+      ...input,
+      startDate: input.startDate.toISOString(),
+      endDate: input.endDate.toISOString(),
+    })
+  ),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) =>
+    service.updateAcademicYear(input.id, {
+      ...input,
+      startDate: input.startDate?.toISOString(),
+      endDate: input.endDate?.toISOString(),
+    })
+  ),
+  setActive: superAdminProcedure.input(setActiveSchema).mutation(({ input }) => service.setActive(input.id, input.isActive)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listAcademicYears(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getAcademicYearById(input.id)),
+});

--- a/apps/server/src/routers/classCourses.router.ts
+++ b/apps/server/src/routers/classCourses.router.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/classCourses.service";
+
+const baseSchema = z.object({ class: z.string(), course: z.string(), teacher: z.string() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const listSchema = z.object({ classId: z.string().optional(), courseId: z.string().optional(), teacherId: z.string().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+const idSchema = z.object({ id: z.string() });
+
+export const classCoursesRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) => service.createClassCourse(input)),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateClassCourse(input.id, input)),
+  delete: adminProcedure.input(idSchema).mutation(({ input }) => service.deleteClassCourse(input.id)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listClassCourses(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getClassCourseById(input.id)),
+});

--- a/apps/server/src/routers/classes.router.ts
+++ b/apps/server/src/routers/classes.router.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/classes.service";
+
+const baseSchema = z.object({ name: z.string(), program: z.string(), academicYear: z.string() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const listSchema = z.object({ programId: z.string().optional(), academicYearId: z.string().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+const idSchema = z.object({ id: z.string() });
+const transferSchema = z.object({ studentId: z.string(), toClassId: z.string() });
+
+export const classesRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) => service.createClass(input)),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateClass(input.id, input)),
+  delete: adminProcedure.input(idSchema).mutation(({ input }) => service.deleteClass(input.id)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listClasses(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getClassById(input.id)),
+  transferStudent: adminProcedure.input(transferSchema).mutation(({ input }) => service.transferStudent(input.studentId, input.toClassId)),
+});

--- a/apps/server/src/routers/courses.router.ts
+++ b/apps/server/src/routers/courses.router.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/courses.service";
+
+const baseSchema = z.object({ name: z.string(), credits: z.number(), hours: z.number(), program: z.string(), defaultTeacher: z.string() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const listSchema = z.object({ programId: z.string().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+const idSchema = z.object({ id: z.string() });
+const assignSchema = z.object({ courseId: z.string(), teacherId: z.string() });
+
+export const coursesRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) => service.createCourse(input)),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateCourse(input.id, input)),
+  delete: adminProcedure.input(idSchema).mutation(({ input }) => service.deleteCourse(input.id)),
+  assignDefaultTeacher: adminProcedure.input(assignSchema).mutation(({ input }) => service.assignDefaultTeacher(input.courseId, input.teacherId)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listCourses(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getCourseById(input.id)),
+});

--- a/apps/server/src/routers/exams.router.ts
+++ b/apps/server/src/routers/exams.router.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/exams.service";
+
+const baseSchema = z.object({ name: z.string(), type: z.string(), date: z.coerce.date(), percentage: z.number(), classCourseId: z.string() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const listSchema = z.object({ classCourseId: z.string().optional(), dateFrom: z.coerce.date().optional(), dateTo: z.coerce.date().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+const idSchema = z.object({ id: z.string() });
+const lockSchema = z.object({ examId: z.string(), lock: z.boolean() });
+
+export const examsRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) => service.createExam({
+    name: input.name,
+    type: input.type,
+    date: input.date,
+    percentage: input.percentage.toString(),
+    classCourse: input.classCourseId,
+  })),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateExam(input.id, {
+    ...input,
+    percentage: input.percentage !== undefined ? input.percentage.toString() : undefined,
+  })),
+  delete: adminProcedure.input(idSchema).mutation(({ input }) => service.deleteExam(input.id)),
+  lock: adminProcedure.input(lockSchema).mutation(({ input }) => service.setLock(input.examId, input.lock)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listExams(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getExamById(input.id)),
+});

--- a/apps/server/src/routers/faculties.router.ts
+++ b/apps/server/src/routers/faculties.router.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure, superAdminProcedure } from "../lib/trpc";
+import * as service from "../services/faculties.service";
+
+const createSchema = z.object({ name: z.string(), description: z.string().optional() });
+const updateSchema = z.object({ id: z.string(), name: z.string().optional(), description: z.string().optional() });
+const idSchema = z.object({ id: z.string() });
+const listSchema = z.object({ q: z.string().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+
+export const facultiesRouter = router({
+  create: adminProcedure.input(createSchema).mutation(({ input }) => service.createFaculty(input)),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateFaculty(input.id, input)),
+  delete: superAdminProcedure.input(idSchema).mutation(({ input }) => service.deleteFaculty(input.id)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listFaculties(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getFacultyById(input.id)),
+});

--- a/apps/server/src/routers/grades.router.ts
+++ b/apps/server/src/routers/grades.router.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/grades.service";
+
+const upsertSchema = z.object({ studentId: z.string(), examId: z.string(), score: z.number() });
+const updateSchema = z.object({ id: z.string(), score: z.number() });
+const idSchema = z.object({ id: z.string() });
+const listExamSchema = z.object({ examId: z.string(), cursor: z.string().optional(), limit: z.number().optional() });
+const listStudentSchema = z.object({ studentId: z.string(), cursor: z.string().optional(), limit: z.number().optional() });
+const listClassCourseSchema = z.object({ classCourseId: z.string(), cursor: z.string().optional(), limit: z.number().optional() });
+const avgExamSchema = z.object({ examId: z.string() });
+const avgCourseSchema = z.object({ courseId: z.string() });
+const avgStudentCourseSchema = z.object({ studentId: z.string(), courseId: z.string() });
+
+export const gradesRouter = router({
+  upsertNote: adminProcedure.input(upsertSchema).mutation(({ input }) => service.upsertNote(input.studentId, input.examId, input.score)),
+  updateNote: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateNote(input.id, input.score)),
+  deleteNote: adminProcedure.input(idSchema).mutation(({ input }) => service.deleteNote(input.id)),
+  listByExam: protectedProcedure.input(listExamSchema).query(({ input }) => service.listByExam(input)),
+  listByStudent: protectedProcedure.input(listStudentSchema).query(({ input }) => service.listByStudent(input)),
+  listByClassCourse: protectedProcedure.input(listClassCourseSchema).query(({ input }) => service.listByClassCourse(input)),
+  avgForExam: protectedProcedure.input(avgExamSchema).query(({ input }) => service.avgForExam(input.examId)),
+  avgForCourse: protectedProcedure.input(avgCourseSchema).query(({ input }) => service.avgForCourse(input.courseId)),
+  avgForStudentInCourse: protectedProcedure.input(avgStudentCourseSchema).query(({ input }) => service.avgForStudentInCourse(input.studentId, input.courseId)),
+});

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -1,14 +1,31 @@
-import { protectedProcedure, publicProcedure, router } from "../lib/trpc";
+import { router, publicProcedure, protectedProcedure } from "../lib/trpc";
+import { facultiesRouter } from "./faculties.router";
+import { programsRouter } from "./programs.router";
+import { academicYearsRouter } from "./academicYears.router";
+import { classesRouter } from "./classes.router";
+import { profilesRouter } from "./profiles.router";
+import { coursesRouter } from "./courses.router";
+import { classCoursesRouter } from "./classCourses.router";
+import { examsRouter } from "./exams.router";
+import { studentsRouter } from "./students.router";
+import { gradesRouter } from "./grades.router";
 
 export const appRouter = router({
-	healthCheck: publicProcedure.query(() => {
-		return "OK";
-	}),
-	privateData: protectedProcedure.query(({ ctx }) => {
-		return {
-			message: "This is private",
-			user: ctx.session.user,
-		};
-	}),
+  healthCheck: publicProcedure.query(() => "OK"),
+  privateData: protectedProcedure.query(({ ctx }) => ({
+    message: "This is private",
+    user: ctx.session.user,
+  })),
+  faculties: facultiesRouter,
+  programs: programsRouter,
+  academicYears: academicYearsRouter,
+  classes: classesRouter,
+  profiles: profilesRouter,
+  courses: coursesRouter,
+  classCourses: classCoursesRouter,
+  exams: examsRouter,
+  students: studentsRouter,
+  grades: gradesRouter,
 });
+
 export type AppRouter = typeof appRouter;

--- a/apps/server/src/routers/profiles.router.ts
+++ b/apps/server/src/routers/profiles.router.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { router, adminProcedure, superAdminProcedure } from "../lib/trpc";
+import * as service from "../services/profiles.service";
+
+const idSchema = z.object({ id: z.string() });
+const emailSchema = z.object({ email: z.string().email() });
+const listSchema = z.object({ cursor: z.string().optional(), limit: z.number().optional() });
+const updateRoleSchema = z.object({ profileId: z.string(), role: z.string() });
+
+export const profilesRouter = router({
+  getById: adminProcedure.input(idSchema).query(({ input }) => service.getProfileById(input.id)),
+  getByEmail: adminProcedure.input(emailSchema).query(({ input }) => service.getProfileByEmail(input.email)),
+  list: adminProcedure.input(listSchema).query(({ input }) => service.listProfiles(input)),
+  updateRole: superAdminProcedure.input(updateRoleSchema).mutation(({ input }) => service.updateRole(input.profileId, input.role)),
+});

--- a/apps/server/src/routers/programs.router.ts
+++ b/apps/server/src/routers/programs.router.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/programs.service";
+
+const baseSchema = z.object({ name: z.string(), description: z.string().optional(), faculty: z.string() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const listSchema = z.object({ facultyId: z.string().optional(), q: z.string().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+const idSchema = z.object({ id: z.string() });
+
+export const programsRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) => service.createProgram(input)),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateProgram(input.id, input)),
+  delete: adminProcedure.input(idSchema).mutation(({ input }) => service.deleteProgram(input.id)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listPrograms(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getProgramById(input.id)),
+});

--- a/apps/server/src/routers/students.router.ts
+++ b/apps/server/src/routers/students.router.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { router, protectedProcedure, adminProcedure } from "../lib/trpc";
+import * as service from "../services/students.service";
+
+const baseSchema = z.object({ firstName: z.string(), lastName: z.string(), email: z.string().email(), registrationNumber: z.string(), classId: z.string() });
+const updateSchema = baseSchema.partial().extend({ id: z.string() });
+const listSchema = z.object({ classId: z.string().optional(), q: z.string().optional(), cursor: z.string().optional(), limit: z.number().optional() });
+const idSchema = z.object({ id: z.string() });
+
+export const studentsRouter = router({
+  create: adminProcedure.input(baseSchema).mutation(({ input }) => service.createStudent({
+    firstName: input.firstName,
+    lastName: input.lastName,
+    email: input.email,
+    registrationNumber: input.registrationNumber,
+    class: input.classId,
+  })),
+  update: adminProcedure.input(updateSchema).mutation(({ input }) => service.updateStudent(input.id, input)),
+  list: protectedProcedure.input(listSchema).query(({ input }) => service.listStudents(input)),
+  getById: protectedProcedure.input(idSchema).query(({ input }) => service.getStudentById(input.id)),
+});

--- a/apps/server/src/services/academicYears.service.ts
+++ b/apps/server/src/services/academicYears.service.ts
@@ -1,0 +1,35 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/academicYears.repo";
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq } from "drizzle-orm";
+
+export async function createAcademicYear(data: Parameters<typeof repo.create>[0]) {
+  return repo.create(data);
+}
+
+export async function updateAcademicYear(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function listAcademicYears(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getAcademicYearById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}
+
+export async function setActive(id: string, isActive: boolean) {
+  await db.transaction(async (tx) => {
+    if (isActive) {
+      await tx.update(schema.academicYears).set({ isActive: false }).where(eq(schema.academicYears.isActive, true));
+    }
+    await tx.update(schema.academicYears).set({ isActive }).where(eq(schema.academicYears.id, id));
+  });
+  return repo.findById(id);
+}

--- a/apps/server/src/services/classCourses.service.ts
+++ b/apps/server/src/services/classCourses.service.ts
@@ -1,0 +1,26 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/classCourses.repo";
+
+export async function createClassCourse(data: Parameters<typeof repo.create>[0]) {
+  return repo.create(data);
+}
+
+export async function updateClassCourse(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function deleteClassCourse(id: string) {
+  await repo.remove(id);
+}
+
+export async function listClassCourses(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getClassCourseById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}

--- a/apps/server/src/services/classes.service.ts
+++ b/apps/server/src/services/classes.service.ts
@@ -1,0 +1,44 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/classes.repo";
+import * as studentsRepo from "../repositories/students.repo";
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq } from "drizzle-orm";
+
+export async function createClass(data: Parameters<typeof repo.create>[0]) {
+  return repo.create(data);
+}
+
+export async function updateClass(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function deleteClass(id: string) {
+  await repo.remove(id);
+}
+
+export async function listClasses(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getClassById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}
+
+export async function transferStudent(studentId: string, toClassId: string) {
+  const student = await studentsRepo.findById(studentId);
+  if (!student) throw new TRPCError({ code: "NOT_FOUND", message: "Student not found" });
+  const target = await repo.findById(toClassId);
+  if (!target) throw new TRPCError({ code: "NOT_FOUND", message: "Class not found" });
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.students)
+      .set({ class: toClassId })
+      .where(eq(schema.students.id, studentId));
+  });
+  return studentsRepo.findById(studentId);
+}

--- a/apps/server/src/services/courses.service.ts
+++ b/apps/server/src/services/courses.service.ts
@@ -1,0 +1,32 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/courses.repo";
+
+export async function createCourse(data: Parameters<typeof repo.create>[0]) {
+  return repo.create(data);
+}
+
+export async function updateCourse(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function deleteCourse(id: string) {
+  await repo.remove(id);
+}
+
+export async function listCourses(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getCourseById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}
+
+export async function assignDefaultTeacher(courseId: string, teacherId: string) {
+  const existing = await repo.findById(courseId);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.assignDefaultTeacher(courseId, teacherId);
+}

--- a/apps/server/src/services/exams.service.ts
+++ b/apps/server/src/services/exams.service.ts
@@ -1,0 +1,67 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/exams.repo";
+import { db } from "../db";
+import * as schema from "../db/schema/app-schema";
+import { eq, sql } from "drizzle-orm";
+
+export async function createExam(data: Parameters<typeof repo.create>[0]) {
+  let created;
+  await db.transaction(async (tx) => {
+    const [{ total }] = await tx
+      .select({ total: sql<number>`coalesce(sum(${schema.exams.percentage}),0)` })
+      .from(schema.exams)
+      .where(eq(schema.exams.classCourse, data.classCourse));
+    if (Number(total) + Number(data.percentage) > 100) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "Percentage exceeds 100" });
+    }
+    [created] = await tx.insert(schema.exams).values(data).returning();
+  });
+  return created;
+}
+
+export async function updateExam(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  if (existing.isLocked) throw new TRPCError({ code: "FORBIDDEN" });
+  if (data.percentage !== undefined) {
+    await db.transaction(async (tx) => {
+      const [{ total }] = await tx
+        .select({ total: sql<number>`coalesce(sum(${schema.exams.percentage}),0)` })
+        .from(schema.exams)
+        .where(eq(schema.exams.classCourse, existing.classCourse));
+      const newTotal = Number(total) - Number(existing.percentage) + Number(data.percentage);
+      if (newTotal > 100) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Percentage exceeds 100" });
+      }
+      await tx
+        .update(schema.exams)
+        .set(data)
+        .where(eq(schema.exams.id, id));
+    });
+    return repo.findById(id);
+  }
+  return repo.update(id, data);
+}
+
+export async function deleteExam(id: string) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  if (existing.isLocked) throw new TRPCError({ code: "FORBIDDEN" });
+  await repo.remove(id);
+}
+
+export async function listExams(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getExamById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}
+
+export async function setLock(examId: string, lock: boolean) {
+  const existing = await repo.findById(examId);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.setLock(examId, lock);
+}

--- a/apps/server/src/services/faculties.service.ts
+++ b/apps/server/src/services/faculties.service.ts
@@ -1,0 +1,26 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/faculties.repo";
+
+export async function createFaculty(data: Parameters<typeof repo.create>[0]) {
+  return repo.create(data);
+}
+
+export async function updateFaculty(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function deleteFaculty(id: string) {
+  await repo.remove(id);
+}
+
+export async function listFaculties(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getFacultyById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}

--- a/apps/server/src/services/grades.service.ts
+++ b/apps/server/src/services/grades.service.ts
@@ -1,0 +1,54 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/grades.repo";
+import * as examsRepo from "../repositories/exams.repo";
+
+export async function upsertNote(studentId: string, examId: string, score: number) {
+  const exam = await examsRepo.findById(examId);
+  if (!exam) throw new TRPCError({ code: "NOT_FOUND" });
+  if (exam.isLocked) throw new TRPCError({ code: "FORBIDDEN" });
+  try {
+    return await repo.upsert({ student: studentId, exam: examId, score: score.toString() });
+  } catch (e) {
+    throw new TRPCError({ code: "CONFLICT" });
+  }
+}
+
+export async function updateNote(id: string, score: number) {
+  const grade = await repo.findById(id);
+  if (!grade) throw new TRPCError({ code: "NOT_FOUND" });
+  const exam = await examsRepo.findById(grade.exam);
+  if (exam?.isLocked) throw new TRPCError({ code: "FORBIDDEN" });
+  return repo.update(id, score.toString());
+}
+
+export async function deleteNote(id: string) {
+  const grade = await repo.findById(id);
+  if (!grade) throw new TRPCError({ code: "NOT_FOUND" });
+  const exam = await examsRepo.findById(grade.exam);
+  if (exam?.isLocked) throw new TRPCError({ code: "FORBIDDEN" });
+  await repo.remove(id);
+}
+
+export async function listByExam(opts: Parameters<typeof repo.listByExam>[0]) {
+  return repo.listByExam(opts);
+}
+
+export async function listByStudent(opts: Parameters<typeof repo.listByStudent>[0]) {
+  return repo.listByStudent(opts);
+}
+
+export async function listByClassCourse(opts: Parameters<typeof repo.listByClassCourse>[0]) {
+  return repo.listByClassCourse(opts);
+}
+
+export async function avgForExam(examId: string) {
+  return repo.avgForExam(examId);
+}
+
+export async function avgForCourse(courseId: string) {
+  return repo.avgForCourse(courseId);
+}
+
+export async function avgForStudentInCourse(studentId: string, courseId: string) {
+  return repo.avgForStudentInCourse(studentId, courseId);
+}

--- a/apps/server/src/services/profiles.service.ts
+++ b/apps/server/src/services/profiles.service.ts
@@ -1,0 +1,24 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/profiles.repo";
+
+export async function getProfileById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}
+
+export async function getProfileByEmail(email: string) {
+  const item = await repo.findByEmail(email);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}
+
+export async function listProfiles(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function updateRole(profileId: string, role: string) {
+  const existing = await repo.findById(profileId);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.updateRole(profileId, role);
+}

--- a/apps/server/src/services/programs.service.ts
+++ b/apps/server/src/services/programs.service.ts
@@ -1,0 +1,26 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/programs.repo";
+
+export async function createProgram(data: Parameters<typeof repo.create>[0]) {
+  return repo.create(data);
+}
+
+export async function updateProgram(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function deleteProgram(id: string) {
+  await repo.remove(id);
+}
+
+export async function listPrograms(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getProgramById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}

--- a/apps/server/src/services/students.service.ts
+++ b/apps/server/src/services/students.service.ts
@@ -1,0 +1,26 @@
+import { TRPCError } from "@trpc/server";
+import * as repo from "../repositories/students.repo";
+
+export async function createStudent(data: Parameters<typeof repo.create>[0]) {
+  try {
+    return await repo.create(data);
+  } catch (e) {
+    throw new TRPCError({ code: "CONFLICT" });
+  }
+}
+
+export async function updateStudent(id: string, data: Parameters<typeof repo.update>[1]) {
+  const existing = await repo.findById(id);
+  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  return repo.update(id, data);
+}
+
+export async function listStudents(opts: Parameters<typeof repo.list>[0]) {
+  return repo.list(opts);
+}
+
+export async function getStudentById(id: string) {
+  const item = await repo.findById(id);
+  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  return item;
+}


### PR DESCRIPTION
## Summary
- add repositories, services, and routers for academic entities
- enforce exam percentage limits and locking for grade safety
- expose full appRouter with new modules

## Testing
- `bun run check-types`


------
https://chatgpt.com/codex/tasks/task_b_68c5a71c5f308327936495bea0d29528