### PR TITLE
feat: add bun test suite with in-memory db

### DIFF
--- a/apps/server/bunfig.toml
+++ b/apps/server/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+root = "."
+preload = "./src/lib/test-setup.ts"
+coverage = true

--- a/apps/server/src/lib/test-db.ts
+++ b/apps/server/src/lib/test-db.ts
@@ -1,0 +1,54 @@
+import { PGlite } from "pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import * as schema from "../db/schema/app-schema";
+import * as authSchema from "../db/schema/auth";
+import { sql } from "drizzle-orm";
+import path from "node:path";
+
+const pg = new PGlite();
+export const db = drizzle(pg, { schema: { ...schema, ...authSchema } });
+
+export async function pushSchema() {
+  const migrationsFolder = path.resolve(import.meta.dir, "../db/migrations");
+  await migrate(db, { migrationsFolder });
+}
+
+export async function seed() {
+  await db.insert(schema.profiles).values({
+    id: "seed-teacher",
+    firstName: "Seed",
+    lastName: "Teacher",
+    email: "seed.teacher@example.com",
+    role: "ADMIN",
+  });
+  const [faculty] = await db
+    .insert(schema.faculties)
+    .values({ name: "Seed Faculty" })
+    .returning();
+  const [year] = await db
+    .insert(schema.academicYears)
+    .values({
+      name: "2024",
+      startDate: new Date("2024-01-01").toISOString(),
+      endDate: new Date("2024-12-31").toISOString(),
+    })
+    .returning();
+  const [program] = await db
+    .insert(schema.programs)
+    .values({ name: "Seed Program", faculty: faculty.id })
+    .returning();
+  await db.insert(schema.classes).values({
+    name: "Seed Class",
+    program: program.id,
+    academicYear: year.id,
+  });
+}
+
+export async function reset() {
+  await db.execute(sql`TRUNCATE TABLE grades, exams, class_courses, courses, classes, programs, faculties, academic_years, profiles, students RESTART IDENTITY CASCADE`);
+}
+
+export async function close() {
+  await pg.close();
+}

--- a/apps/server/src/lib/test-setup.ts
+++ b/apps/server/src/lib/test-setup.ts
@@ -1,0 +1,23 @@
+import { config } from "dotenv";
+import { beforeAll, beforeEach, afterAll, mock } from "bun:test";
+import { db, pushSchema, seed, reset, close } from "./test-db";
+
+try {
+  config({ path: ".env.test" });
+} catch {}
+
+mock.module("../db", () => ({ db }));
+
+beforeAll(async () => {
+  await pushSchema();
+  await seed();
+});
+
+beforeEach(async () => {
+  await reset();
+  await seed();
+});
+
+afterAll(async () => {
+  await close();
+});

--- a/apps/server/src/lib/test-utils.ts
+++ b/apps/server/src/lib/test-utils.ts
@@ -1,0 +1,143 @@
+import type { Context } from "./context";
+import { db } from "./test-db";
+import * as schema from "../db/schema/app-schema";
+import { randomUUID } from "node:crypto";
+
+export function makeTestContext(opts: { role?: string; userId?: string } = {}): Context {
+  const { role, userId } = { role: undefined as string | undefined, userId: randomUUID(), ...opts };
+  if (!role) return { session: null } as unknown as Context;
+  return {
+    session: {
+      user: { id: userId, role },
+    },
+  } as Context;
+}
+
+export const asAdmin = () => makeTestContext({ role: "ADMIN" });
+export const asSuperAdmin = () => makeTestContext({ role: "superadmin" });
+export const asUser = () => makeTestContext({ role: "USER" });
+
+export async function createFaculty(data: Partial<schema.NewFaculty> = {}) {
+  const [faculty] = await db
+    .insert(schema.faculties)
+    .values({ name: `Faculty-${randomUUID()}`, ...data })
+    .returning();
+  return faculty;
+}
+
+export async function createProgram(data: Partial<schema.NewProgram> = {}) {
+  const faculty = data.faculty ? { id: data.faculty } : await createFaculty();
+  const [program] = await db
+    .insert(schema.programs)
+    .values({ name: `Program-${randomUUID()}`, faculty: faculty.id, ...data })
+    .returning();
+  return program;
+}
+
+export async function createAcademicYear(data: Partial<schema.NewAcademicYear> = {}) {
+  const [year] = await db
+    .insert(schema.academicYears)
+    .values({
+      name: `AY-${randomUUID()}`,
+      startDate: data.startDate ?? new Date("2024-01-01").toISOString(),
+      endDate: data.endDate ?? new Date("2024-12-31").toISOString(),
+      ...data,
+    })
+    .returning();
+  return year;
+}
+
+export async function createClass(data: Partial<schema.NewKlass> = {}) {
+  const program = data.program ? { id: data.program } : await createProgram();
+  const year = data.academicYear ? { id: data.academicYear } : await createAcademicYear();
+  const [klass] = await db
+    .insert(schema.classes)
+    .values({ name: `Class-${randomUUID()}`, program: program.id, academicYear: year.id, ...data })
+    .returning();
+  return klass;
+}
+
+export async function createProfile(data: Partial<schema.NewProfile> = {}) {
+  const [profile] = await db
+    .insert(schema.profiles)
+    .values({
+      id: randomUUID(),
+      firstName: "John",
+      lastName: "Doe",
+      email: `user-${randomUUID()}@example.com`,
+      role: data.role ?? "ADMIN",
+      ...data,
+    })
+    .returning();
+  return profile;
+}
+
+export async function createCourse(data: Partial<schema.NewCourse> = {}) {
+  const program = data.program ? { id: data.program } : await createProgram();
+  const teacher = data.defaultTeacher ? { id: data.defaultTeacher } : await createProfile();
+  const [course] = await db
+    .insert(schema.courses)
+    .values({
+      name: `Course-${randomUUID()}`,
+      credits: data.credits ?? 3,
+      hours: data.hours ?? 30,
+      program: program.id,
+      defaultTeacher: teacher.id,
+      ...data,
+    })
+    .returning();
+  return course;
+}
+
+export async function createClassCourse(data: Partial<schema.NewClassCourse> = {}) {
+  const klass = data.class ? { id: data.class } : await createClass();
+  const course = data.course ? { id: data.course } : await createCourse();
+  const teacher = data.teacher ? { id: data.teacher } : await createProfile();
+  const [cc] = await db
+    .insert(schema.classCourses)
+    .values({ class: klass.id, course: course.id, teacher: teacher.id, ...data })
+    .returning();
+  return cc;
+}
+
+export async function createExam(data: Partial<schema.NewExam> = {}) {
+  const classCourse = data.classCourse ? { id: data.classCourse } : await createClassCourse();
+  const [exam] = await db
+    .insert(schema.exams)
+    .values({
+      name: `Exam-${randomUUID()}`,
+      type: data.type ?? "WRITTEN",
+      date: data.date ?? new Date(),
+      percentage: data.percentage?.toString() ?? "50",
+      classCourse: classCourse.id,
+      ...data,
+    })
+    .returning();
+  return exam;
+}
+
+export async function createStudent(data: Partial<schema.NewStudent> = {}) {
+  const klass = data.class ? { id: data.class } : await createClass();
+  const [student] = await db
+    .insert(schema.students)
+    .values({
+      firstName: "Stu",
+      lastName: "Dent",
+      email: data.email ?? `student-${randomUUID()}@example.com`,
+      registrationNumber: data.registrationNumber ?? randomUUID(),
+      class: klass.id,
+      ...data,
+    })
+    .returning();
+  return student;
+}
+
+export async function createGrade(data: Partial<schema.NewGrade> = {}) {
+  const student = data.student ? { id: data.student } : await createStudent();
+  const exam = data.exam ? { id: data.exam } : await createExam();
+  const [grade] = await db
+    .insert(schema.grades)
+    .values({ student: student.id, exam: exam.id, score: data.score?.toString() ?? "50" })
+    .returning();
+  return grade;
+}

--- a/apps/server/src/routers/__tests__/academicYears.caller.test.ts
+++ b/apps/server/src/routers/__tests__/academicYears.caller.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, asSuperAdmin } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("academic years router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.academicYears.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("supports CRUD and setActive", async () => {
+    const admin = createCaller(asAdmin());
+    const year = await admin.academicYears.create({ name: "2025", startDate: new Date(), endDate: new Date(Date.now() + 86400000) });
+    expect(year.id).toBeTruthy();
+
+    const updated = await admin.academicYears.update({ id: year.id, name: "2025/2026" });
+    expect(updated.name).toBe("2025/2026");
+
+    const superCaller = createCaller(asSuperAdmin());
+    const set = await superCaller.academicYears.setActive({ id: year.id, isActive: true });
+    expect(set.isActive).toBe(true);
+  });
+});

--- a/apps/server/src/routers/__tests__/classCourses.caller.test.ts
+++ b/apps/server/src/routers/__tests__/classCourses.caller.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createClass, createCourse, createProfile } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("class courses router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.classCourses.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("supports CRUD", async () => {
+    const klass = await createClass();
+    const course = await createCourse({ program: klass.program });
+    const teacher = await createProfile();
+    const admin = createCaller(asAdmin());
+    const cc = await admin.classCourses.create({ class: klass.id, course: course.id, teacher: teacher.id });
+    expect(cc.class).toBe(klass.id);
+
+    const updated = await admin.classCourses.update({ id: cc.id, teacher: teacher.id });
+    expect(updated.teacher).toBe(teacher.id);
+
+    await admin.classCourses.delete({ id: cc.id });
+    const list = await admin.classCourses.list({ classId: klass.id });
+    expect(list.items.length).toBe(0);
+  });
+});

--- a/apps/server/src/routers/__tests__/classes.caller.test.ts
+++ b/apps/server/src/routers/__tests__/classes.caller.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createClass, createStudent } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("classes router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.classes.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("supports CRUD and transfer", async () => {
+    const admin = createCaller(asAdmin());
+    const cls = await createClass();
+    const newCls = await admin.classes.create({ name: "B", program: cls.program, academicYear: cls.academicYear });
+    const student = await createStudent({ class: cls.id });
+    const transferred = await admin.classes.transferStudent({ studentId: student.id, toClassId: newCls.id });
+    expect(transferred?.class).toBe(newCls.id);
+
+    await admin.classes.delete({ id: newCls.id });
+    const list = await admin.classes.list({ programId: cls.program });
+    expect(list.items.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/server/src/routers/__tests__/courses.caller.test.ts
+++ b/apps/server/src/routers/__tests__/courses.caller.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createProgram, createProfile } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("courses router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.courses.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("supports CRUD", async () => {
+    const program = await createProgram();
+    const teacher = await createProfile();
+    const admin = createCaller(asAdmin());
+    const course = await admin.courses.create({ name: "Math", credits: 3, hours: 30, program: program.id, defaultTeacher: teacher.id });
+    expect(course.program).toBe(program.id);
+
+    const updated = await admin.courses.update({ id: course.id, name: "Math2" });
+    expect(updated.name).toBe("Math2");
+
+    await admin.courses.delete({ id: course.id });
+    const list = await admin.courses.list({ programId: program.id });
+    expect(list.items.length).toBe(0);
+  });
+});

--- a/apps/server/src/routers/__tests__/e2e.http.test.ts
+++ b/apps/server/src/routers/__tests__/e2e.http.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { trpcServer } from "@hono/trpc-server";
+import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
+import { appRouter, type AppRouter } from "../index";
+import { asAdmin, createProfile } from "../../lib/test-utils";
+
+const app = new Hono();
+app.use("/trpc/*", trpcServer({ router: appRouter, createContext: () => asAdmin() }));
+app.get("/", (c) => c.text("OK"));
+
+const client = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: "/trpc",
+      fetch: (input, init) => app.request(input, init),
+    }),
+  ],
+});
+
+describe("e2e http", () => {
+  it("health check", async () => {
+    const res = await app.request("/");
+    expect(await res.text()).toBe("OK");
+  });
+
+  it("creates full flow", async () => {
+    const faculty = await client.faculties.create.mutate({ name: "F" });
+    const program = await client.programs.create.mutate({ name: "P", faculty: faculty.id });
+    const year = await client.academicYears.create.mutate({ name: "2025", startDate: new Date(), endDate: new Date(Date.now() + 86400000) });
+    const klass = await client.classes.create.mutate({ name: "C", program: program.id, academicYear: year.id });
+    const teacher = await createProfile();
+    const course = await client.courses.create.mutate({ name: "Math", credits: 3, hours: 30, program: program.id, defaultTeacher: teacher.id });
+    const cc = await client.classCourses.create.mutate({ class: klass.id, course: course.id, teacher: teacher.id });
+    const exam = await client.exams.create.mutate({ name: "Mid", type: "WRITTEN", date: new Date(), percentage: 50, classCourseId: cc.id });
+    const student = await client.students.create.mutate({ firstName: "A", lastName: "B", email: "e2e@example.com", registrationNumber: "R1", classId: klass.id });
+    await client.grades.upsertNote.mutate({ studentId: student.id, examId: exam.id, score: 90 });
+    const list = await client.grades.listByExam.query({ examId: exam.id });
+    expect(list.items.length).toBe(1);
+  });
+});

--- a/apps/server/src/routers/__tests__/exams.caller.test.ts
+++ b/apps/server/src/routers/__tests__/exams.caller.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createClassCourse, createStudent } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("exams router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.exams.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("enforces percentage and lock", async () => {
+    const admin = createCaller(asAdmin());
+    const cc = await createClassCourse();
+    const exam = await admin.exams.create({ name: "Mid", type: "WRITTEN", date: new Date(), percentage: 60, classCourseId: cc.id });
+    await expect(
+      admin.exams.create({ name: "Final", type: "WRITTEN", date: new Date(), percentage: 50, classCourseId: cc.id })
+    ).rejects.toHaveProperty("code", "BAD_REQUEST");
+
+    await admin.exams.lock({ examId: exam.id, lock: true });
+    await expect(admin.exams.update({ id: exam.id, name: "M" })).rejects.toHaveProperty("code", "FORBIDDEN");
+    await expect(admin.exams.delete({ id: exam.id })).rejects.toHaveProperty("code", "FORBIDDEN");
+
+    const student = await createStudent({ class: cc.class });
+    await expect(
+      admin.grades.upsertNote({ studentId: student.id, examId: exam.id, score: 80 })
+    ).rejects.toHaveProperty("code", "FORBIDDEN");
+  });
+});

--- a/apps/server/src/routers/__tests__/faculties.caller.test.ts
+++ b/apps/server/src/routers/__tests__/faculties.caller.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, asSuperAdmin } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("faculties router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.faculties.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("enforces roles", async () => {
+    const caller = createCaller(makeTestContext({ role: "USER" }));
+    await expect(caller.faculties.create({ name: "F1" })).rejects.toHaveProperty("code", "FORBIDDEN");
+  });
+
+  it("supports CRUD", async () => {
+    const admin = createCaller(asAdmin());
+    const faculty = await admin.faculties.create({ name: "Science" });
+    expect(faculty.id).toBeTruthy();
+
+    const fetched = await admin.faculties.getById({ id: faculty.id });
+    expect(fetched.name).toBe("Science");
+
+    const updated = await admin.faculties.update({ id: faculty.id, name: "Sci" });
+    expect(updated.name).toBe("Sci");
+
+    const list = await admin.faculties.list({ limit: 1 });
+    expect(list.items.length).toBe(1);
+
+    const superCaller = createCaller(asSuperAdmin());
+    await superCaller.faculties.delete({ id: faculty.id });
+    const after = await superCaller.faculties.list({});
+    expect(after.items.length).toBe(0);
+  });
+});

--- a/apps/server/src/routers/__tests__/grades.caller.test.ts
+++ b/apps/server/src/routers/__tests__/grades.caller.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createExam, createStudent } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("grades router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.grades.listByExam({ examId: "x" })).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("upserts and respects locks", async () => {
+    const admin = createCaller(asAdmin());
+    const exam = await createExam();
+    const student = await createStudent();
+    const grade = await admin.grades.upsertNote({ studentId: student.id, examId: exam.id, score: 70 });
+    const updated = await admin.grades.upsertNote({ studentId: student.id, examId: exam.id, score: 80 });
+    expect(updated.id).toBe(grade.id);
+    expect(new Date(updated.updatedAt).getTime()).toBeGreaterThan(new Date(grade.updatedAt).getTime());
+
+    await admin.exams.lock({ examId: exam.id, lock: true });
+    await expect(
+      admin.grades.updateNote({ id: grade.id, score: 50 })
+    ).rejects.toHaveProperty("code", "FORBIDDEN");
+  });
+});

--- a/apps/server/src/routers/__tests__/profiles.caller.test.ts
+++ b/apps/server/src/routers/__tests__/profiles.caller.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, asSuperAdmin } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("profiles router", () => {
+  it("requires admin", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.profiles.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("lists and updates role", async () => {
+    const admin = createCaller(asAdmin());
+    const list = await admin.profiles.list({});
+    expect(list.items.length).toBeGreaterThan(0);
+
+    const profile = list.items[0];
+    const superCaller = createCaller(asSuperAdmin());
+    const updated = await superCaller.profiles.updateRole({ profileId: profile.id, role: "ADMIN" });
+    expect(updated.role).toBe("ADMIN");
+  });
+});

--- a/apps/server/src/routers/__tests__/programs.caller.test.ts
+++ b/apps/server/src/routers/__tests__/programs.caller.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createFaculty } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("programs router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.programs.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("supports CRUD", async () => {
+    const faculty = await createFaculty();
+    const admin = createCaller(asAdmin());
+    const program = await admin.programs.create({ name: "Prog", faculty: faculty.id });
+    expect(program.faculty).toBe(faculty.id);
+
+    const list = await admin.programs.list({ facultyId: faculty.id });
+    expect(list.items[0].id).toBe(program.id);
+
+    const updated = await admin.programs.update({ id: program.id, name: "Prog2" });
+    expect(updated.name).toBe("Prog2");
+
+    await admin.programs.delete({ id: program.id });
+    const after = await admin.programs.list({ facultyId: faculty.id });
+    expect(after.items.length).toBe(0);
+  });
+});

--- a/apps/server/src/routers/__tests__/students.caller.test.ts
+++ b/apps/server/src/routers/__tests__/students.caller.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { createCallerFactory } from "@trpc/server";
+import { appRouter } from "../index";
+import { makeTestContext, asAdmin, createClass } from "../../lib/test-utils";
+
+const createCaller = createCallerFactory(appRouter);
+
+describe("students router", () => {
+  it("requires auth", async () => {
+    const caller = createCaller(makeTestContext());
+    await expect(caller.students.list({})).rejects.toHaveProperty("code", "UNAUTHORIZED");
+  });
+
+  it("enforces uniqueness", async () => {
+    const admin = createCaller(asAdmin());
+    const klass = await createClass();
+    await admin.students.create({ firstName: "A", lastName: "B", email: "s@example.com", registrationNumber: "1", classId: klass.id });
+    await expect(
+      admin.students.create({ firstName: "A", lastName: "B", email: "s@example.com", registrationNumber: "2", classId: klass.id })
+    ).rejects.toHaveProperty("code", "CONFLICT");
+  });
+});


### PR DESCRIPTION
## Summary
- setup Bun test environment for server app with coverage
- add in-memory PGlite database helpers, seeding and context factories
- add caller and e2e tests for all routers

## Testing
- `bun test apps/server` *(fails: Cannot find package 'pglite')*

------
https://chatgpt.com/codex/tasks/task_b_68c5af0329108327bee23c1ca368f613