### PR TITLE
refactor: migrate academic years to module architecture

### DIFF
--- a/apps/server/src/modules/_shared/auth-guards.ts
+++ b/apps/server/src/modules/_shared/auth-guards.ts
@@ -1,0 +1,8 @@
+import { TRPCError } from "@trpc/server";
+
+export function requireRole(session: { user?: { role?: string } }, roles: string[]) {
+  const role = session.user?.role;
+  if (!role || !roles.includes(role)) {
+    throw new TRPCError({ code: "FORBIDDEN" });
+  }
+}

--- a/apps/server/src/modules/_shared/db-transaction.ts
+++ b/apps/server/src/modules/_shared/db-transaction.ts
@@ -1,0 +1,5 @@
+import { db } from "../../db";
+
+export function transaction<T>(fn: Parameters<typeof db.transaction>[0]) {
+  return db.transaction(fn);
+}

--- a/apps/server/src/modules/_shared/errors.ts
+++ b/apps/server/src/modules/_shared/errors.ts
@@ -1,0 +1,9 @@
+import { TRPCError } from "@trpc/server";
+
+export function notFound(message = "Resource not found") {
+  return new TRPCError({ code: "NOT_FOUND", message });
+}
+
+export function conflict(message = "Conflict") {
+  return new TRPCError({ code: "CONFLICT", message });
+}

--- a/apps/server/src/modules/_shared/pagination.ts
+++ b/apps/server/src/modules/_shared/pagination.ts
@@ -1,0 +1,4 @@
+export function paginate<T extends { id: string }>(items: T[], limit: number) {
+  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
+  return { items, nextCursor };
+}

--- a/apps/server/src/modules/academic-years/__tests__/academic-years.caller.test.ts
+++ b/apps/server/src/modules/academic-years/__tests__/academic-years.caller.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { createCallerFactory } from "@trpc/server";
-import { appRouter } from "../index";
-import { makeTestContext, asAdmin, asSuperAdmin } from "../../lib/test-utils";
+import { appRouter } from "../../../routers";
+import { makeTestContext, asAdmin, asSuperAdmin } from "../../../lib/test-utils";
 
 const createCaller = createCallerFactory(appRouter);
 

--- a/apps/server/src/modules/academic-years/academic-years.repo.ts
+++ b/apps/server/src/modules/academic-years/academic-years.repo.ts
@@ -1,6 +1,7 @@
-import { db } from "../db";
-import * as schema from "../db/schema/app-schema";
+import { db } from "../../db";
+import * as schema from "../../db/schema/app-schema";
 import { eq, gt } from "drizzle-orm";
+import { paginate } from "../_shared/pagination";
 
 export async function create(data: schema.NewAcademicYear) {
   const [item] = await db.insert(schema.academicYears).values(data).returning();
@@ -32,6 +33,5 @@ export async function list(opts: { cursor?: string; limit?: number }) {
     .where(condition)
     .orderBy(schema.academicYears.id)
     .limit(limit);
-  const nextCursor = items.length === limit ? items[items.length - 1].id : undefined;
-  return { items, nextCursor };
+  return paginate(items, limit);
 }

--- a/apps/server/src/modules/academic-years/academic-years.router.ts
+++ b/apps/server/src/modules/academic-years/academic-years.router.ts
@@ -1,14 +1,8 @@
-import { z } from "zod";
-import { router, protectedProcedure, adminProcedure, superAdminProcedure } from "../lib/trpc";
-import * as service from "../services/academicYears.service";
+import { router as createRouter, protectedProcedure, adminProcedure, superAdminProcedure } from "../../lib/trpc";
+import * as service from "./academic-years.service";
+import { baseSchema, updateSchema, idSchema, listSchema, setActiveSchema } from "./academic-years.zod";
 
-const baseSchema = z.object({ name: z.string(), startDate: z.coerce.date(), endDate: z.coerce.date() });
-const updateSchema = baseSchema.partial().extend({ id: z.string() });
-const idSchema = z.object({ id: z.string() });
-const listSchema = z.object({ cursor: z.string().optional(), limit: z.number().optional() });
-const setActiveSchema = z.object({ id: z.string(), isActive: z.boolean() });
-
-export const academicYearsRouter = router({
+export const router = createRouter({
   create: adminProcedure.input(baseSchema).mutation(({ input }) =>
     service.createAcademicYear({
       ...input,

--- a/apps/server/src/modules/academic-years/academic-years.service.ts
+++ b/apps/server/src/modules/academic-years/academic-years.service.ts
@@ -1,8 +1,8 @@
-import { TRPCError } from "@trpc/server";
-import * as repo from "../repositories/academicYears.repo";
-import { db } from "../db";
-import * as schema from "../db/schema/app-schema";
+import * as repo from "./academic-years.repo";
+import * as schema from "../../db/schema/app-schema";
 import { eq } from "drizzle-orm";
+import { notFound } from "../_shared/errors";
+import { transaction } from "../_shared/db-transaction";
 
 export async function createAcademicYear(data: Parameters<typeof repo.create>[0]) {
   return repo.create(data);
@@ -10,7 +10,7 @@ export async function createAcademicYear(data: Parameters<typeof repo.create>[0]
 
 export async function updateAcademicYear(id: string, data: Parameters<typeof repo.update>[1]) {
   const existing = await repo.findById(id);
-  if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+  if (!existing) throw notFound();
   return repo.update(id, data);
 }
 
@@ -20,16 +20,22 @@ export async function listAcademicYears(opts: Parameters<typeof repo.list>[0]) {
 
 export async function getAcademicYearById(id: string) {
   const item = await repo.findById(id);
-  if (!item) throw new TRPCError({ code: "NOT_FOUND" });
+  if (!item) throw notFound();
   return item;
 }
 
 export async function setActive(id: string, isActive: boolean) {
-  await db.transaction(async (tx) => {
+  await transaction(async (tx) => {
     if (isActive) {
-      await tx.update(schema.academicYears).set({ isActive: false }).where(eq(schema.academicYears.isActive, true));
+      await tx
+        .update(schema.academicYears)
+        .set({ isActive: false })
+        .where(eq(schema.academicYears.isActive, true));
     }
-    await tx.update(schema.academicYears).set({ isActive }).where(eq(schema.academicYears.id, id));
+    await tx
+      .update(schema.academicYears)
+      .set({ isActive })
+      .where(eq(schema.academicYears.id, id));
   });
   return repo.findById(id);
 }

--- a/apps/server/src/modules/academic-years/academic-years.zod.ts
+++ b/apps/server/src/modules/academic-years/academic-years.zod.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const baseSchema = z.object({
+  name: z.string(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+});
+
+export const updateSchema = baseSchema.partial().extend({ id: z.string() });
+
+export const idSchema = z.object({ id: z.string() });
+
+export const listSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().optional(),
+});
+
+export const setActiveSchema = z.object({
+  id: z.string(),
+  isActive: z.boolean(),
+});

--- a/apps/server/src/modules/academic-years/index.ts
+++ b/apps/server/src/modules/academic-years/index.ts
@@ -1,0 +1,1 @@
+export { router as academicYearsRouter } from "./academic-years.router";

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -1,7 +1,7 @@
 import { router, publicProcedure, protectedProcedure } from "../lib/trpc";
 import { facultiesRouter } from "./faculties.router";
 import { programsRouter } from "./programs.router";
-import { academicYearsRouter } from "./academicYears.router";
+import { academicYearsRouter } from "../modules/academic-years";
 import { classesRouter } from "./classes.router";
 import { profilesRouter } from "./profiles.router";
 import { coursesRouter } from "./courses.router";


### PR DESCRIPTION
## Summary
- migrate academic years feature into `src/modules/academic-years`
- add shared helpers for pagination, errors, auth guards and db transactions
- update app router to consume academic years module

## Testing
- `bun test` *(fails: Cannot find package 'pglite' from test-db.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68c5cb0452608327b20dacd15549a5fd