### PR TITLE
Fix test setup order

### DIFF
--- a/apps/server/src/lib/test-setup.ts
+++ b/apps/server/src/lib/test-setup.ts
@@ -9,8 +9,8 @@ try {
 mock.module("../db", () => ({ db }));
 
 beforeAll(async () => {
-  await reset();
   await pushSchema();
+  await reset();
   await seed();
 });
 


### PR DESCRIPTION
## Summary
- ensure test schema is pushed before resetting in test setup

## Testing
- `bun test` *(fails: Cannot find module '@electric-sql/pglite')*


------
https://chatgpt.com/codex/tasks/task_b_68c679be30b48327a4c0018c90a0bf22