### PR TITLE
feat(web): migrate Supabase auth to BetterAuth

### DIFF
--- a/apps/web/src/components/navigation/Header.tsx
+++ b/apps/web/src/components/navigation/Header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Menu, Bell, X, LogOut } from 'lucide-react';
 import { useStore } from '../../store';
-import { supabase } from '../../lib/supabase';
+import { authClient } from '../../lib/auth-client';
 import { toast } from 'sonner';
 
 const Header: React.FC = () => {
@@ -11,7 +11,7 @@ const Header: React.FC = () => {
 
   const handleLogout = async () => {
     try {
-      await supabase.auth.signOut();
+      await authClient.signOut();
       clearUser();
       navigate('/login');
       toast.success('Logged out successfully');

--- a/apps/web/src/pages/auth/ForgotPassword.tsx
+++ b/apps/web/src/pages/auth/ForgotPassword.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { authClient } from "../../lib/auth-client";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+const schema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+});
+
+type FormData = z.infer<typeof schema>;
+
+const ForgotPassword: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await authClient.requestPasswordReset({
+        email: data.email,
+        redirectTo: `${window.location.origin}/auth/reset`,
+      });
+      toast.success("Password reset link sent");
+    } catch (error: any) {
+      toast.error(error.message || "Failed to send reset link");
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-center mb-6">Forgot Password</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            {...register("email")}
+            className="input input-bordered w-full"
+          />
+          {errors.email && (
+            <p className="mt-1 text-sm text-error-600">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="btn btn-primary w-full mt-6"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Sending...
+            </>
+          ) : (
+            "Send Reset Link"
+          )}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ForgotPassword;
+

--- a/apps/web/src/pages/auth/Login.tsx
+++ b/apps/web/src/pages/auth/Login.tsx
@@ -3,7 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { supabase } from '../../lib/supabase';
+import { authClient } from '../../lib/auth-client';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 
@@ -27,14 +27,10 @@ const Login: React.FC = () => {
 
   const onSubmit = async (data: LoginFormData) => {
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      await authClient.signIn.email({
         email: data.email,
         password: data.password,
       });
-
-      if (error) {
-        throw error;
-      }
 
       toast.success('Successfully signed in');
       // Navigation happens automatically through auth state change listener

--- a/apps/web/src/pages/auth/ResetPassword.tsx
+++ b/apps/web/src/pages/auth/ResetPassword.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { authClient } from "../../lib/auth-client";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+const schema = z
+  .object({
+    password: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z
+      .string()
+      .min(6, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+type FormData = z.infer<typeof schema>;
+
+const ResetPassword: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token") || "";
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await authClient.resetPassword({
+        token,
+        newPassword: data.password,
+      });
+      toast.success("Password reset successfully");
+      navigate("/login");
+    } catch (error: any) {
+      toast.error(error.message || "Failed to reset password");
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-center mb-6">Reset Password</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            New Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            {...register("password")}
+            className="input input-bordered w-full"
+          />
+          {errors.password && (
+            <p className="mt-1 text-sm text-error-600">
+              {errors.password.message}
+            </p>
+          )}
+        </div>
+        <div>
+          <label
+            htmlFor="confirmPassword"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Confirm Password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            {...register("confirmPassword")}
+            className="input input-bordered w-full"
+          />
+          {errors.confirmPassword && (
+            <p className="mt-1 text-sm text-error-600">
+              {errors.confirmPassword.message}
+            </p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="btn btn-primary w-full mt-6"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Resetting...
+            </>
+          ) : (
+            "Reset Password"
+          )}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ResetPassword;
+


### PR DESCRIPTION
## Summary
- replace Supabase login, registration, and logout calls with BetterAuth client
- load session via BetterAuth and add forgot/reset password pages
- wire up routes for new password reset flow

## Testing
- `bun run check` (fails: lint errors across repository)
- `cd apps/web && bun run lint` (fails: ESLint config not found)


------
https://chatgpt.com/codex/tasks/task_b_68c6967b6a1c8327b3eb689428494d3c