### PR TITLE
feat: unify auth routes and simplify registration

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -54,8 +54,8 @@ function App() {
     <Routes>
       {/* Auth Routes */}
       <Route element={<AuthLayout />}>
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
+        <Route path="/auth/login" element={<Login />} />
+        <Route path="/auth/register" element={<Register />} />
         <Route path="/auth/forgot" element={<ForgotPassword />} />
         <Route path="/auth/reset" element={<ResetPassword />} />
       </Route>
@@ -97,7 +97,7 @@ function App() {
               <Navigate to="/teacher" replace />
             )
           ) : (
-            <Navigate to="/login" replace />
+            <Navigate to="/auth/login" replace />
           )
         }
       />

--- a/apps/web/src/components/layouts/DashboardLayout.tsx
+++ b/apps/web/src/components/layouts/DashboardLayout.tsx
@@ -13,7 +13,7 @@ const DashboardLayout: React.FC = () => {
   // Redirect if not authenticated
   useEffect(() => {
     if (!user) {
-      navigate('/login', { replace: true });
+      navigate('/auth/login', { replace: true });
     }
   }, [user, navigate]);
 

--- a/apps/web/src/components/navigation/Header.tsx
+++ b/apps/web/src/components/navigation/Header.tsx
@@ -13,7 +13,7 @@ const Header: React.FC = () => {
     try {
       await authClient.signOut();
       clearUser();
-      navigate('/login');
+      navigate('/auth/login');
       toast.success('Logged out successfully');
     } catch (error) {
       console.error('Error logging out:', error);

--- a/apps/web/src/pages/auth/Login.tsx
+++ b/apps/web/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -15,8 +15,6 @@ const loginSchema = z.object({
 type LoginFormData = z.infer<typeof loginSchema>;
 
 const Login: React.FC = () => {
-  const navigate = useNavigate();
-  
   const {
     register,
     handleSubmit,
@@ -74,6 +72,11 @@ const Login: React.FC = () => {
           {errors.password && (
             <p className="mt-1 text-sm text-error-600">{errors.password.message}</p>
           )}
+          <div className="mt-1 text-right">
+            <Link to="/auth/forgot" className="text-sm text-primary-600 hover:text-primary-500">
+              Forgot password?
+            </Link>
+          </div>
         </div>
         
         <button
@@ -94,7 +97,7 @@ const Login: React.FC = () => {
       <div className="mt-6 text-center">
         <p className="text-sm text-gray-600">
           Need an account?{' '}
-          <Link to="/register" className="text-primary-600 hover:text-primary-500 font-medium">
+          <Link to="/auth/register" className="text-primary-600 hover:text-primary-500 font-medium">
             Register
           </Link>
         </p>

--- a/apps/web/src/pages/auth/Register.tsx
+++ b/apps/web/src/pages/auth/Register.tsx
@@ -7,17 +7,18 @@ import { authClient } from '../../lib/auth-client';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 
-const loginSchema = z.object({
-  firstName: z.string().min(2, 'First name is required'),
-  lastName: z.string().min(2, 'Last name is required'),
-  email: z.string().email('Please enter a valid email address'),
-  password: z.string().min(6, 'Password must be at least 6 characters'),
-  confirmPassword: z.string().min(6, 'Please confirm your password'),
-  role: z.enum(['admin', 'teacher']),
-}).refine((data) => data.password === data.confirmPassword, {
-  message: "Passwords don't match",
-  path: ['confirmPassword'],
-});
+const loginSchema = z
+  .object({
+    firstName: z.string().min(2, 'First name is required'),
+    lastName: z.string().min(2, 'Last name is required'),
+    email: z.string().email('Please enter a valid email address'),
+    password: z.string().min(6, 'Password must be at least 6 characters'),
+    confirmPassword: z.string().min(6, 'Please confirm your password'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
 
 type RegisterFormData = z.infer<typeof loginSchema>;
 
@@ -30,9 +31,6 @@ const Register: React.FC = () => {
     formState: { errors, isSubmitting },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(loginSchema),
-    defaultValues: {
-      role: 'teacher',
-    },
   });
 
   const onSubmit = async (data: RegisterFormData) => {
@@ -41,7 +39,7 @@ const Register: React.FC = () => {
         email: data.email,
         password: data.password,
         name: `${data.firstName} ${data.lastName}`,
-        role: data.role.toUpperCase(),
+        role: 'TEACHER',
       });
 
       await authClient.signIn.email({
@@ -50,7 +48,7 @@ const Register: React.FC = () => {
       });
 
       toast.success('Registration successful!');
-      navigate(data.role === 'admin' ? '/admin' : '/teacher');
+      navigate('/teacher');
     } catch (error: any) {
       toast.error(`Registration failed: ${error.message}`);
     }
@@ -138,19 +136,6 @@ const Register: React.FC = () => {
           )}
         </div>
         
-        <div>
-          <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">
-            Role
-          </label>
-          <select
-            id="role"
-            {...register('role')}
-            className="select select-bordered w-full"
-          >
-            <option value="teacher">Teacher</option>
-            <option value="admin">Administrator</option>
-          </select>
-        </div>
         
         <button
           type="submit"
@@ -170,7 +155,7 @@ const Register: React.FC = () => {
       <div className="mt-6 text-center">
         <p className="text-sm text-gray-600">
           Already have an account?{' '}
-          <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
+          <Link to="/auth/login" className="text-primary-600 hover:text-primary-500 font-medium">
             Sign In
           </Link>
         </p>

--- a/apps/web/src/pages/auth/ResetPassword.tsx
+++ b/apps/web/src/pages/auth/ResetPassword.tsx
@@ -39,7 +39,7 @@ const ResetPassword: React.FC = () => {
         newPassword: data.password,
       });
       toast.success("Password reset successfully");
-      navigate("/login");
+      navigate("/auth/login");
     } catch (error: any) {
       toast.error(error.message || "Failed to reset password");
     }


### PR DESCRIPTION
## Summary
- add forgot password link on login screen
- prefix all auth pages with `/auth`
- remove role selection from registration and default to teacher

## Testing
- `bunx biome check apps/web/src` *(fails: extra lint warnings in existing files)*
- `bun run --cwd apps/web lint` *(fails: ESLint config missing)*
- `bun run --cwd apps/web build` *(fails: vite command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c69bf320748327b6024d13434a1a42