### PR TITLE
feat(web): add trpc-based teacher management pages

### DIFF
--- a/apps/web/src/pages/teacher/ClassCourseManagement.tsx
+++ b/apps/web/src/pages/teacher/ClassCourseManagement.tsx
@@ -1,0 +1,431 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { BookOpen, Pencil, Plus, Trash2 } from "lucide-react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import ConfirmModal from "../../components/modals/ConfirmModal";
+import FormModal from "../../components/modals/FormModal";
+import { trpcClient } from "../../utils/trpc";
+
+const classCourseSchema = z.object({
+	class: z.string().uuid("Please select a class"),
+	course: z.string().uuid("Please select a course"),
+	teacher: z.string().uuid("Please select a teacher"),
+});
+
+type ClassCourseFormData = z.infer<typeof classCourseSchema>;
+
+interface ClassCourse {
+	id: string;
+	class: string;
+	course: string;
+	teacher: string;
+}
+
+interface Class {
+	id: string;
+	name: string;
+	program: string;
+}
+
+interface Course {
+	id: string;
+	name: string;
+}
+
+interface Program {
+	id: string;
+	name: string;
+}
+
+interface Teacher {
+	id: string;
+	firstName: string;
+	lastName: string;
+	role: string;
+}
+
+export default function ClassCourseManagement() {
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	const [editingClassCourse, setEditingClassCourse] =
+		useState<ClassCourse | null>(null);
+	const [deleteId, setDeleteId] = useState<string | null>(null);
+
+	const queryClient = useQueryClient();
+
+	const { data: activeYear } = useQuery({
+		queryKey: ["activeYear"],
+		queryFn: async () => {
+			const { items } = await trpcClient.academicYears.list.query({});
+			return items.find((y: any) => y.isActive);
+		},
+	});
+
+	const { data: classes } = useQuery({
+		queryKey: ["activeClasses", activeYear?.id],
+		queryFn: async () => {
+			if (!activeYear) return [];
+			const { items } = await trpcClient.classes.list.query({
+				academicYearId: activeYear.id,
+			});
+			return items as Class[];
+		},
+		enabled: !!activeYear,
+	});
+
+	const { data: programs } = useQuery({
+		queryKey: ["programs"],
+		queryFn: async () => {
+			const { items } = await trpcClient.programs.list.query({});
+			return items as Program[];
+		},
+	});
+
+	const { data: courses } = useQuery({
+		queryKey: ["courses"],
+		queryFn: async () => {
+			const { items } = await trpcClient.courses.list.query({});
+			return items as Course[];
+		},
+	});
+
+	const { data: teachers } = useQuery({
+		queryKey: ["teachers"],
+		queryFn: async () => {
+			const { items } = await trpcClient.profiles.list.query({});
+			return items.filter((t: Teacher) => t.role === "teacher") as Teacher[];
+		},
+	});
+
+	const { data: classCourses, isLoading } = useQuery({
+		queryKey: ["classCourses"],
+		queryFn: async () => {
+			const { items } = await trpcClient.classCourses.list.query({});
+			return items as ClassCourse[];
+		},
+	});
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors, isSubmitting },
+	} = useForm<ClassCourseFormData>({
+		resolver: zodResolver(classCourseSchema),
+	});
+
+	const classMap = new Map((classes ?? []).map((c) => [c.id, c]));
+	const courseMap = new Map((courses ?? []).map((c) => [c.id, c.name]));
+	const programMap = new Map((programs ?? []).map((p) => [p.id, p.name]));
+	const teacherMap = new Map(
+		(teachers ?? []).map((t) => [t.id, `${t.firstName} ${t.lastName}`]),
+	);
+	const activeClassIds = new Set((classes ?? []).map((c) => c.id));
+	const displayedClassCourses = (classCourses ?? []).filter((cc) =>
+		activeClassIds.has(cc.class),
+	);
+
+	const createMutation = useMutation({
+		mutationFn: async (data: ClassCourseFormData) => {
+			await trpcClient.classCourses.create.mutate(data);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["classCourses"] });
+			toast.success("Course assignment created successfully");
+			setIsFormOpen(false);
+			reset();
+		},
+		onError: (error: any) => {
+			toast.error(`Error creating course assignment: ${error.message}`);
+		},
+	});
+
+	const updateMutation = useMutation({
+		mutationFn: async (data: ClassCourseFormData & { id: string }) => {
+			const { id, ...updateData } = data;
+			await trpcClient.classCourses.update.mutate({ id, ...updateData });
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["classCourses"] });
+			toast.success("Course assignment updated successfully");
+			setIsFormOpen(false);
+			setEditingClassCourse(null);
+			reset();
+		},
+		onError: (error: any) => {
+			toast.error(`Error updating course assignment: ${error.message}`);
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: async (id: string) => {
+			await trpcClient.classCourses.delete.mutate({ id });
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["classCourses"] });
+			toast.success("Course assignment deleted successfully");
+			setIsDeleteOpen(false);
+			setDeleteId(null);
+		},
+		onError: (error: any) => {
+			toast.error(`Error deleting course assignment: ${error.message}`);
+		},
+	});
+
+	const onSubmit = async (data: ClassCourseFormData) => {
+		if (editingClassCourse) {
+			updateMutation.mutate({ ...data, id: editingClassCourse.id });
+		} else {
+			createMutation.mutate(data);
+		}
+	};
+
+	const openDeleteModal = (id: string) => {
+		setDeleteId(id);
+		setIsDeleteOpen(true);
+	};
+
+	const handleDelete = () => {
+		if (deleteId) {
+			deleteMutation.mutate(deleteId);
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<span className="loading loading-spinner loading-lg" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="p-6">
+			<div className="mb-6 flex items-center justify-between">
+				<div>
+					<h1 className="font-bold text-2xl">Course Assignments</h1>
+					<p className="text-base-content/60">
+						Manage course assignments for classes
+					</p>
+				</div>
+				<button
+					onClick={() => {
+						setEditingClassCourse(null);
+						reset();
+						setIsFormOpen(true);
+					}}
+					className="btn btn-primary"
+				>
+					<Plus className="mr-2 h-5 w-5" />
+					Assign Course
+				</button>
+			</div>
+
+			<div className="card bg-base-100 shadow-xl">
+				{displayedClassCourses.length === 0 ? (
+					<div className="card-body items-center py-12 text-center">
+						<BookOpen className="h-16 w-16 text-base-content/20" />
+						<h2 className="card-title mt-4">No Course Assignments</h2>
+						<p className="text-base-content/60">
+							Get started by assigning a course to a class.
+						</p>
+						<button
+							onClick={() => {
+								setEditingClassCourse(null);
+								reset();
+								setIsFormOpen(true);
+							}}
+							className="btn btn-primary mt-4"
+						>
+							<Plus className="mr-2 h-4 w-4" />
+							Assign Course
+						</button>
+					</div>
+				) : (
+					<div className="overflow-x-auto">
+						<table className="table">
+							<thead>
+								<tr>
+									<th>Class</th>
+									<th>Program</th>
+									<th>Course</th>
+									<th>Teacher</th>
+									<th>Actions</th>
+								</tr>
+							</thead>
+							<tbody>
+								{displayedClassCourses?.map((cc) => (
+									<tr key={cc.id}>
+										<td className="font-medium">
+											{classMap.get(cc.class)?.name}
+										</td>
+										<td>
+											{programMap.get(classMap.get(cc.class)?.program || "")}
+										</td>
+										<td>{courseMap.get(cc.course)}</td>
+										<td>{teacherMap.get(cc.teacher)}</td>
+										<td>
+											<div className="flex gap-2">
+												<button
+													onClick={() => {
+														setEditingClassCourse(cc);
+														reset({
+															class: cc.class,
+															course: cc.course,
+															teacher: cc.teacher,
+														});
+														setIsFormOpen(true);
+													}}
+													className="btn btn-square btn-sm btn-ghost"
+												>
+													<Pencil className="h-4 w-4" />
+												</button>
+												<button
+													onClick={() => openDeleteModal(cc.id)}
+													className="btn btn-square btn-sm btn-ghost text-error"
+												>
+													<Trash2 className="h-4 w-4" />
+												</button>
+											</div>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+
+			<FormModal
+				isOpen={isFormOpen}
+				onClose={() => {
+					setIsFormOpen(false);
+					setEditingClassCourse(null);
+					reset();
+				}}
+				title={
+					editingClassCourse
+						? "Edit Course Assignment"
+						: "New Course Assignment"
+				}
+			>
+				<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Class</span>
+						</label>
+						<select
+							{...register("class")}
+							className="select select-bordered w-full"
+						>
+							<option value="">Select a class</option>
+							{classes?.map((cls) => (
+								<option key={cls.id} value={cls.id}>
+									{cls.name} - {programMap.get(cls.program)}
+								</option>
+							))}
+						</select>
+						{errors.class && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.class.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Course</span>
+						</label>
+						<select
+							{...register("course")}
+							className="select select-bordered w-full"
+						>
+							<option value="">Select a course</option>
+							{courses?.map((course) => (
+								<option key={course.id} value={course.id}>
+									{course.name}
+								</option>
+							))}
+						</select>
+						{errors.course && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.course.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Teacher</span>
+						</label>
+						<select
+							{...register("teacher")}
+							className="select select-bordered w-full"
+						>
+							<option value="">Select a teacher</option>
+							{teachers?.map((teacher) => (
+								<option key={teacher.id} value={teacher.id}>
+									{teacher.firstName} {teacher.lastName}
+								</option>
+							))}
+						</select>
+						{errors.teacher && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.teacher.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="modal-action">
+						<button
+							type="button"
+							onClick={() => {
+								setIsFormOpen(false);
+								setEditingClassCourse(null);
+								reset();
+							}}
+							className="btn btn-ghost"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							className="btn btn-primary"
+							disabled={isSubmitting}
+						>
+							{isSubmitting ? (
+								<span className="loading loading-spinner loading-sm" />
+							) : editingClassCourse ? (
+								"Save Changes"
+							) : (
+								"Create Assignment"
+							)}
+						</button>
+					</div>
+				</form>
+			</FormModal>
+
+			<ConfirmModal
+				isOpen={isDeleteOpen}
+				onClose={() => {
+					setIsDeleteOpen(false);
+					setDeleteId(null);
+				}}
+				onConfirm={handleDelete}
+				title="Delete Course Assignment"
+				message="Are you sure you want to delete this course assignment? This action cannot be undone and will also delete all associated exams and grades."
+				confirmText="Delete"
+				isLoading={deleteMutation.isPending}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/pages/teacher/CourseManagement.tsx
+++ b/apps/web/src/pages/teacher/CourseManagement.tsx
@@ -1,0 +1,394 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Pencil, PlusIcon, Trash2 } from "lucide-react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import ConfirmModal from "../../components/modals/ConfirmModal";
+import FormModal from "../../components/modals/FormModal";
+import { trpcClient } from "../../utils/trpc";
+
+const courseSchema = z.object({
+	name: z.string().min(2, "Name must be at least 2 characters"),
+	credits: z.number().min(1, "Credits must be at least 1"),
+	hours: z.number().min(1, "Hours must be at least 1"),
+	program: z.string().uuid("Please select a program"),
+	defaultTeacher: z.string().uuid("Please select a teacher"),
+});
+
+type CourseFormData = z.infer<typeof courseSchema>;
+
+interface Course {
+	id: string;
+	name: string;
+	credits: number;
+	hours: number;
+	program: string;
+	defaultTeacher: string;
+}
+
+interface Program {
+	id: string;
+	name: string;
+}
+
+interface Teacher {
+	id: string;
+	firstName: string;
+	lastName: string;
+	role: string;
+}
+
+export default function CourseManagement() {
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	const [editingCourse, setEditingCourse] = useState<Course | null>(null);
+	const [deleteId, setDeleteId] = useState<string | null>(null);
+
+	const queryClient = useQueryClient();
+
+	const { data: courses, isLoading } = useQuery({
+		queryKey: ["courses"],
+		queryFn: async () => {
+			const { items } = await trpcClient.courses.list.query({});
+			return items as Course[];
+		},
+	});
+
+	const { data: programs } = useQuery({
+		queryKey: ["programs"],
+		queryFn: async () => {
+			const { items } = await trpcClient.programs.list.query({});
+			return items as Program[];
+		},
+	});
+
+	const { data: teachers } = useQuery({
+		queryKey: ["teachers"],
+		queryFn: async () => {
+			const { items } = await trpcClient.profiles.list.query({});
+			return items.filter((t: Teacher) => t.role === "teacher") as Teacher[];
+		},
+	});
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors, isSubmitting },
+	} = useForm<CourseFormData>({
+		resolver: zodResolver(courseSchema),
+	});
+
+	const programMap = new Map((programs ?? []).map((p) => [p.id, p.name]));
+	const teacherMap = new Map(
+		(teachers ?? []).map((t) => [t.id, `${t.firstName} ${t.lastName}`]),
+	);
+
+	const createMutation = useMutation({
+		mutationFn: async (data: CourseFormData) => {
+			await trpcClient.courses.create.mutate(data);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["courses"] });
+			toast.success("Course created successfully");
+			setIsFormOpen(false);
+			reset();
+		},
+		onError: (error: any) => {
+			toast.error(`Error creating course: ${error.message}`);
+		},
+	});
+
+	const updateMutation = useMutation({
+		mutationFn: async (data: CourseFormData & { id: string }) => {
+			const { id, ...updateData } = data;
+			await trpcClient.courses.update.mutate({ id, ...updateData });
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["courses"] });
+			toast.success("Course updated successfully");
+			setIsFormOpen(false);
+			setEditingCourse(null);
+			reset();
+		},
+		onError: (error: any) => {
+			toast.error(`Error updating course: ${error.message}`);
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: async (id: string) => {
+			await trpcClient.courses.delete.mutate({ id });
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["courses"] });
+			toast.success("Course deleted successfully");
+			setIsDeleteOpen(false);
+			setDeleteId(null);
+		},
+		onError: (error: any) => {
+			toast.error(`Error deleting course: ${error.message}`);
+		},
+	});
+
+	const onSubmit = async (data: CourseFormData) => {
+		if (editingCourse) {
+			updateMutation.mutate({ ...data, id: editingCourse.id });
+		} else {
+			createMutation.mutate(data);
+		}
+	};
+
+	const openDeleteModal = (id: string) => {
+		setDeleteId(id);
+		setIsDeleteOpen(true);
+	};
+
+	const handleDelete = () => {
+		if (deleteId) {
+			deleteMutation.mutate(deleteId);
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<span className="loading loading-spinner loading-lg" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="p-6">
+			<div className="mb-6 flex items-center justify-between">
+				<h1 className="font-bold text-2xl">Course Management</h1>
+				<button
+					onClick={() => {
+						setEditingCourse(null);
+						reset();
+						setIsFormOpen(true);
+					}}
+					className="btn btn-primary"
+				>
+					<PlusIcon className="mr-2 h-5 w-5" />
+					Add Course
+				</button>
+			</div>
+
+			<div className="card bg-base-100 shadow-xl">
+				<div className="overflow-x-auto">
+					<table className="table">
+						<thead>
+							<tr>
+								<th>Name</th>
+								<th>Program</th>
+								<th>Credits</th>
+								<th>Hours</th>
+								<th>Default Teacher</th>
+								<th>Actions</th>
+							</tr>
+						</thead>
+						<tbody>
+							{courses?.map((course) => (
+								<tr key={course.id}>
+									<td>{course.name}</td>
+									<td>{programMap.get(course.program)}</td>
+									<td>{course.credits}</td>
+									<td>{course.hours}</td>
+									<td>{teacherMap.get(course.defaultTeacher)}</td>
+									<td>
+										<div className="flex gap-2">
+											<button
+												onClick={() => {
+													setEditingCourse(course);
+													reset({
+														name: course.name,
+														credits: course.credits,
+														hours: course.hours,
+														program: course.program,
+														defaultTeacher: course.defaultTeacher,
+													});
+													setIsFormOpen(true);
+												}}
+												className="btn btn-square btn-sm btn-ghost"
+											>
+												<Pencil className="h-4 w-4" />
+											</button>
+											<button
+												onClick={() => openDeleteModal(course.id)}
+												className="btn btn-square btn-sm btn-ghost text-error"
+											>
+												<Trash2 className="h-4 w-4" />
+											</button>
+										</div>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+
+			<FormModal
+				isOpen={isFormOpen}
+				onClose={() => {
+					setIsFormOpen(false);
+					setEditingCourse(null);
+					reset();
+				}}
+				title={editingCourse ? "Edit Course" : "Add New Course"}
+			>
+				<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Course Name</span>
+						</label>
+						<input
+							type="text"
+							{...register("name")}
+							className="input input-bordered"
+							placeholder="Enter course name"
+						/>
+						{errors.name && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.name.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="grid grid-cols-2 gap-4">
+						<div className="form-control">
+							<label className="label">
+								<span className="label-text">Credits</span>
+							</label>
+							<input
+								type="number"
+								{...register("credits", { valueAsNumber: true })}
+								className="input input-bordered"
+								placeholder="Enter credits"
+							/>
+							{errors.credits && (
+								<label className="label">
+									<span className="label-text-alt text-error">
+										{errors.credits.message}
+									</span>
+								</label>
+							)}
+						</div>
+
+						<div className="form-control">
+							<label className="label">
+								<span className="label-text">Hours</span>
+							</label>
+							<input
+								type="number"
+								{...register("hours", { valueAsNumber: true })}
+								className="input input-bordered"
+								placeholder="Enter hours"
+							/>
+							{errors.hours && (
+								<label className="label">
+									<span className="label-text-alt text-error">
+										{errors.hours.message}
+									</span>
+								</label>
+							)}
+						</div>
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Program</span>
+						</label>
+						<select
+							{...register("program")}
+							className="select select-bordered w-full"
+						>
+							<option value="">Select a program</option>
+							{programs?.map((program) => (
+								<option key={program.id} value={program.id}>
+									{program.name}
+								</option>
+							))}
+						</select>
+						{errors.program && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.program.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Default Teacher</span>
+						</label>
+						<select
+							{...register("defaultTeacher")}
+							className="select select-bordered w-full"
+						>
+							<option value="">Select a teacher</option>
+							{teachers?.map((teacher) => (
+								<option key={teacher.id} value={teacher.id}>
+									{teacher.firstName} {teacher.lastName}
+								</option>
+							))}
+						</select>
+						{errors.defaultTeacher && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.defaultTeacher.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="modal-action">
+						<button
+							type="button"
+							onClick={() => {
+								setIsFormOpen(false);
+								setEditingCourse(null);
+								reset();
+							}}
+							className="btn btn-ghost"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							className="btn btn-primary"
+							disabled={isSubmitting}
+						>
+							{isSubmitting ? (
+								<span className="loading loading-spinner loading-sm" />
+							) : editingCourse ? (
+								"Save Changes"
+							) : (
+								"Create Course"
+							)}
+						</button>
+					</div>
+				</form>
+			</FormModal>
+
+			<ConfirmModal
+				isOpen={isDeleteOpen}
+				onClose={() => {
+					setIsDeleteOpen(false);
+					setDeleteId(null);
+				}}
+				onConfirm={handleDelete}
+				title="Delete Course"
+				message="Are you sure you want to delete this course? This action cannot be undone."
+				confirmText="Delete"
+				isLoading={deleteMutation.isPending}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/pages/teacher/ExamManagement.tsx
+++ b/apps/web/src/pages/teacher/ExamManagement.tsx
@@ -1,0 +1,455 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { ClipboardList, Pencil, Plus, Trash2 } from "lucide-react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import ConfirmModal from "../../components/modals/ConfirmModal";
+import FormModal from "../../components/modals/FormModal";
+import { trpcClient } from "../../utils/trpc";
+
+const examSchema = z.object({
+	name: z.string().min(2, "Name must be at least 2 characters"),
+	type: z.string().min(2, "Type must be at least 2 characters"),
+	date: z.string().min(1, "Date is required"),
+	percentage: z
+		.number()
+		.min(1, "Percentage must be at least 1")
+		.max(100, "Percentage cannot exceed 100"),
+	classCourseId: z.string().uuid("Please select a course"),
+});
+
+type ExamFormData = z.infer<typeof examSchema>;
+
+interface Exam {
+	id: string;
+	name: string;
+	type: string;
+	date: string;
+	percentage: number;
+	classCourse: string;
+	isLocked: boolean;
+}
+
+interface ClassCourse {
+	id: string;
+	class: string;
+	course: string;
+}
+
+interface Class {
+	id: string;
+	name: string;
+}
+
+interface Course {
+	id: string;
+	name: string;
+}
+
+export default function ExamManagement() {
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	const [editingExam, setEditingExam] = useState<Exam | null>(null);
+	const [deleteId, setDeleteId] = useState<string | null>(null);
+
+	const queryClient = useQueryClient();
+
+	const { data: exams, isLoading } = useQuery({
+		queryKey: ["exams"],
+		queryFn: async () => {
+			const { items } = await trpcClient.exams.list.query({});
+			return items as Exam[];
+		},
+	});
+
+	const { data: classCourses } = useQuery({
+		queryKey: ["classCourses"],
+		queryFn: async () => {
+			const { items } = await trpcClient.classCourses.list.query({});
+			return items as ClassCourse[];
+		},
+	});
+
+	const { data: classes } = useQuery({
+		queryKey: ["classes"],
+		queryFn: async () => {
+			const { items } = await trpcClient.classes.list.query({});
+			return items as Class[];
+		},
+	});
+
+	const { data: courses } = useQuery({
+		queryKey: ["courses"],
+		queryFn: async () => {
+			const { items } = await trpcClient.courses.list.query({});
+			return items as Course[];
+		},
+	});
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors, isSubmitting },
+	} = useForm<ExamFormData>({
+		resolver: zodResolver(examSchema),
+	});
+
+	const classMap = new Map((classes ?? []).map((c) => [c.id, c.name]));
+	const courseMap = new Map((courses ?? []).map((c) => [c.id, c.name]));
+	const classCourseMap = new Map((classCourses ?? []).map((cc) => [cc.id, cc]));
+
+	const createMutation = useMutation({
+		mutationFn: async (data: ExamFormData) => {
+			await trpcClient.exams.create.mutate({
+				...data,
+				date: new Date(data.date),
+			});
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["exams"] });
+			toast.success("Exam created successfully");
+			setIsFormOpen(false);
+			reset();
+		},
+		onError: (error: any) => {
+			toast.error(`Error creating exam: ${error.message}`);
+		},
+	});
+
+	const updateMutation = useMutation({
+		mutationFn: async (data: ExamFormData & { id: string }) => {
+			const { id, ...updateData } = data;
+			await trpcClient.exams.update.mutate({
+				id,
+				...updateData,
+				date: new Date(updateData.date),
+			});
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["exams"] });
+			toast.success("Exam updated successfully");
+			setIsFormOpen(false);
+			setEditingExam(null);
+			reset();
+		},
+		onError: (error: any) => {
+			toast.error(`Error updating exam: ${error.message}`);
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: async (id: string) => {
+			await trpcClient.exams.delete.mutate({ id });
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["exams"] });
+			toast.success("Exam deleted successfully");
+			setIsDeleteOpen(false);
+			setDeleteId(null);
+		},
+		onError: (error: any) => {
+			toast.error(`Error deleting exam: ${error.message}`);
+		},
+	});
+
+	const onSubmit = async (data: ExamFormData) => {
+		if (editingExam) {
+			updateMutation.mutate({ ...data, id: editingExam.id });
+		} else {
+			createMutation.mutate(data);
+		}
+	};
+
+	const openDeleteModal = (id: string) => {
+		setDeleteId(id);
+		setIsDeleteOpen(true);
+	};
+
+	const handleDelete = () => {
+		if (deleteId) {
+			deleteMutation.mutate(deleteId);
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<span className="loading loading-spinner loading-lg" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="p-6">
+			<div className="mb-6 flex items-center justify-between">
+				<div>
+					<h1 className="font-bold text-2xl">Exam Management</h1>
+					<p className="text-base-content/60">Create and manage course exams</p>
+				</div>
+				<button
+					onClick={() => {
+						setEditingExam(null);
+						reset();
+						setIsFormOpen(true);
+					}}
+					className="btn btn-primary"
+				>
+					<Plus className="mr-2 h-5 w-5" />
+					Add Exam
+				</button>
+			</div>
+
+			<div className="card bg-base-100 shadow-xl">
+				{exams?.length === 0 ? (
+					<div className="card-body items-center py-12 text-center">
+						<ClipboardList className="h-16 w-16 text-base-content/20" />
+						<h2 className="card-title mt-4">No Exams Found</h2>
+						<p className="text-base-content/60">
+							Get started by adding your first exam.
+						</p>
+						<button
+							onClick={() => {
+								setEditingExam(null);
+								reset();
+								setIsFormOpen(true);
+							}}
+							className="btn btn-primary mt-4"
+						>
+							<Plus className="mr-2 h-4 w-4" />
+							Add Exam
+						</button>
+					</div>
+				) : (
+					<div className="overflow-x-auto">
+						<table className="table">
+							<thead>
+								<tr>
+									<th>Name</th>
+									<th>Course</th>
+									<th>Class</th>
+									<th>Type</th>
+									<th>Date</th>
+									<th>Percentage</th>
+									<th>Status</th>
+									<th>Actions</th>
+								</tr>
+							</thead>
+							<tbody>
+								{exams?.map((exam) => (
+									<tr key={exam.id}>
+										<td className="font-medium">{exam.name}</td>
+										<td>
+											{courseMap.get(
+												classCourseMap.get(exam.classCourse)?.course || "",
+											)}
+										</td>
+										<td>
+											{classMap.get(
+												classCourseMap.get(exam.classCourse)?.class || "",
+											)}
+										</td>
+										<td>{exam.type}</td>
+										<td>{format(new Date(exam.date), "MMM d, yyyy")}</td>
+										<td>{exam.percentage}%</td>
+										<td>
+											<span
+												className={`badge ${
+													exam.isLocked ? "badge-warning" : "badge-success"
+												}`}
+											>
+												{exam.isLocked ? "Locked" : "Open"}
+											</span>
+										</td>
+										<td>
+											<div className="flex gap-2">
+												<button
+													onClick={() => {
+														setEditingExam(exam);
+														reset({
+															name: exam.name,
+															type: exam.type,
+															date: exam.date.split("T")[0],
+															percentage: exam.percentage,
+															classCourseId: exam.classCourse,
+														});
+														setIsFormOpen(true);
+													}}
+													className="btn btn-square btn-sm btn-ghost"
+													disabled={exam.isLocked}
+												>
+													<Pencil className="h-4 w-4" />
+												</button>
+												<button
+													onClick={() => openDeleteModal(exam.id)}
+													className="btn btn-square btn-sm btn-ghost text-error"
+													disabled={exam.isLocked}
+												>
+													<Trash2 className="h-4 w-4" />
+												</button>
+											</div>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+
+			<FormModal
+				isOpen={isFormOpen}
+				onClose={() => {
+					setIsFormOpen(false);
+					setEditingExam(null);
+					reset();
+				}}
+				title={editingExam ? "Edit Exam" : "Add New Exam"}
+			>
+				<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Course</span>
+						</label>
+						<select
+							{...register("classCourseId")}
+							className="select select-bordered w-full"
+						>
+							<option value="">Select a course</option>
+							{classCourses?.map((cc) => (
+								<option key={cc.id} value={cc.id}>
+									{courseMap.get(cc.course)} - {classMap.get(cc.class)}
+								</option>
+							))}
+						</select>
+						{errors.classCourseId && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.classCourseId.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Exam Name</span>
+						</label>
+						<input
+							type="text"
+							{...register("name")}
+							className="input input-bordered"
+							placeholder="Enter exam name"
+						/>
+						{errors.name && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.name.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Type</span>
+						</label>
+						<input
+							type="text"
+							{...register("type")}
+							className="input input-bordered"
+							placeholder="e.g., Midterm, Final"
+						/>
+						{errors.type && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.type.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Date</span>
+						</label>
+						<input
+							type="date"
+							{...register("date")}
+							className="input input-bordered"
+						/>
+						{errors.date && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.date.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="form-control">
+						<label className="label">
+							<span className="label-text">Percentage</span>
+						</label>
+						<input
+							type="number"
+							{...register("percentage", { valueAsNumber: true })}
+							className="input input-bordered"
+							placeholder="Enter percentage (1-100)"
+						/>
+						{errors.percentage && (
+							<label className="label">
+								<span className="label-text-alt text-error">
+									{errors.percentage.message}
+								</span>
+							</label>
+						)}
+					</div>
+
+					<div className="modal-action">
+						<button
+							type="button"
+							onClick={() => {
+								setIsFormOpen(false);
+								setEditingExam(null);
+								reset();
+							}}
+							className="btn btn-ghost"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							className="btn btn-primary"
+							disabled={isSubmitting}
+						>
+							{isSubmitting ? (
+								<span className="loading loading-spinner loading-sm" />
+							) : editingExam ? (
+								"Save Changes"
+							) : (
+								"Create Exam"
+							)}
+						</button>
+					</div>
+				</form>
+			</FormModal>
+
+			<ConfirmModal
+				isOpen={isDeleteOpen}
+				onClose={() => {
+					setIsDeleteOpen(false);
+					setDeleteId(null);
+				}}
+				onConfirm={handleDelete}
+				title="Delete Exam"
+				message="Are you sure you want to delete this exam? This action cannot be undone and will also delete all associated grades."
+				confirmText="Delete"
+				isLoading={deleteMutation.isPending}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- add CourseManagement page backed by trpc queries and mutations
- manage class-course assignments with trpc
- handle exam CRUD via trpc in teacher pages

## Testing
- `bun run check` *(fails: useExhaustiveDependencies, noUnusedImports, noExplicitAny, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68c6a4680fe08327af3836af5bee8d0a