### PR TITLE
feat(server): add users listing module

### DIFF
--- a/apps/server/src/modules/users/index.ts
+++ b/apps/server/src/modules/users/index.ts
@@ -1,0 +1,1 @@
+export { usersRouter } from "./users.router";

--- a/apps/server/src/modules/users/users.repo.ts
+++ b/apps/server/src/modules/users/users.repo.ts
@@ -1,0 +1,37 @@
+import { and, eq, gt, type SQL } from "drizzle-orm";
+import { db } from "@/db";
+import { user } from "@/db/schema/auth";
+
+export async function list(opts: {
+	cursor?: string | null;
+	limit?: number;
+	role?: string;
+}) {
+	const limit = Math.min(Math.max(opts.limit ?? 20, 1), 100);
+	let condition: SQL<unknown> | undefined;
+	if (opts.role) {
+		condition = eq(user.role, opts.role);
+	}
+	if (opts.cursor) {
+		const cursorCond = gt(user.id, opts.cursor);
+		condition = condition ? and(condition, cursorCond) : cursorCond;
+	}
+	const items = await db
+		.select({
+			id: user.id,
+			name: user.name,
+			email: user.email,
+			role: user.role,
+			createdAt: user.createdAt,
+		})
+		.from(user)
+		.where(condition)
+		.orderBy(user.id)
+		.limit(limit + 1);
+	let nextCursor: string | undefined;
+	if (items.length > limit) {
+		const nextItem = items.pop();
+		nextCursor = nextItem?.id;
+	}
+	return { items, nextCursor };
+}

--- a/apps/server/src/modules/users/users.router.ts
+++ b/apps/server/src/modules/users/users.router.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+import { protectedProcedure, router } from "../../lib/trpc";
+import * as service from "./users.service";
+
+const listSchema = z.object({
+	cursor: z.string().nullish(),
+	limit: z.number().min(1).max(100).optional(),
+	role: z.string().optional(),
+});
+
+export const usersRouter = router({
+	list: protectedProcedure
+		.input(listSchema)
+		.query(({ input }) => service.listUsers(input)),
+});

--- a/apps/server/src/modules/users/users.service.ts
+++ b/apps/server/src/modules/users/users.service.ts
@@ -1,0 +1,5 @@
+import * as repo from "./users.repo";
+
+export async function listUsers(opts: Parameters<typeof repo.list>[0]) {
+	return repo.list(opts);
+}

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -8,6 +8,7 @@ import { examsRouter } from "../modules/exams";
 import { facultiesRouter } from "../modules/faculties";
 import { programsRouter } from "../modules/programs";
 import { studentsRouter } from "../modules/students";
+import { usersRouter } from "../modules/users";
 
 export const appRouter = router({
 	healthCheck: publicProcedure.query(() => "OK"),
@@ -24,6 +25,7 @@ export const appRouter = router({
 	exams: examsRouter,
 	students: studentsRouter,
 	grades: gradesRouter,
+	users: usersRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/pages/admin/ClassCourseManagement.tsx
+++ b/apps/web/src/pages/admin/ClassCourseManagement.tsx
@@ -41,10 +41,9 @@ interface Program {
 }
 
 interface Teacher {
-	id: string;
-	firstName: string;
-	lastName: string;
-	role: string;
+        id: string;
+        name: string;
+        role: string | null;
 }
 
 export default function ClassCourseManagement() {
@@ -95,7 +94,11 @@ export default function ClassCourseManagement() {
         const { data: teachers } = useQuery({
                 queryKey: ["teachers"],
                 queryFn: async () => {
-                        return [] as Teacher[];
+                        const { items } = await trpcClient.users.list.query({
+                                role: "teacher",
+                                limit: 100,
+                        });
+                        return items as Teacher[];
                 },
         });
 
@@ -119,9 +122,7 @@ export default function ClassCourseManagement() {
 	const classMap = new Map((classes ?? []).map((c) => [c.id, c]));
 	const courseMap = new Map((courses ?? []).map((c) => [c.id, c.name]));
 	const programMap = new Map((programs ?? []).map((p) => [p.id, p.name]));
-	const teacherMap = new Map(
-		(teachers ?? []).map((t) => [t.id, `${t.firstName} ${t.lastName}`]),
-	);
+        const teacherMap = new Map((teachers ?? []).map((t) => [t.id, t.name]));
 	const activeClassIds = new Set((classes ?? []).map((c) => c.id));
 	const displayedClassCourses = (classCourses ?? []).filter((cc) =>
 		activeClassIds.has(cc.class),
@@ -369,11 +370,11 @@ export default function ClassCourseManagement() {
 							className="select select-bordered w-full"
 						>
 							<option value="">Select a teacher</option>
-							{teachers?.map((teacher) => (
-								<option key={teacher.id} value={teacher.id}>
-									{teacher.firstName} {teacher.lastName}
-								</option>
-							))}
+                                                        {teachers?.map((teacher) => (
+                                                                <option key={teacher.id} value={teacher.id}>
+                                                                        {teacher.name}
+                                                                </option>
+                                                        ))}
 						</select>
 						{errors.teacher && (
 							<label className="label">

--- a/apps/web/src/pages/admin/CourseManagement.tsx
+++ b/apps/web/src/pages/admin/CourseManagement.tsx
@@ -34,10 +34,9 @@ interface Program {
 }
 
 interface Teacher {
-	id: string;
-	firstName: string;
-	lastName: string;
-	role: string;
+        id: string;
+        name: string;
+        role: string | null;
 }
 
 export default function CourseManagement() {
@@ -64,12 +63,16 @@ export default function CourseManagement() {
 		},
 	});
 
-	const { data: teachers } = useQuery({
-		queryKey: ["teachers"],
-		queryFn: async () => {
-			return [] as Teacher[];
-		},
-	});
+        const { data: teachers } = useQuery({
+                queryKey: ["teachers"],
+                queryFn: async () => {
+                        const { items } = await trpcClient.users.list.query({
+                                role: "teacher",
+                                limit: 100,
+                        });
+                        return items as Teacher[];
+                },
+        });
 
 	const {
 		register,
@@ -81,9 +84,7 @@ export default function CourseManagement() {
 	});
 
 	const programMap = new Map((programs ?? []).map((p) => [p.id, p.name]));
-	const teacherMap = new Map(
-		(teachers ?? []).map((t) => [t.id, `${t.firstName} ${t.lastName}`]),
-	);
+        const teacherMap = new Map((teachers ?? []).map((t) => [t.id, t.name]));
 
 	const createMutation = useMutation({
 		mutationFn: async (data: CourseFormData) => {
@@ -332,11 +333,11 @@ export default function CourseManagement() {
 							className="select select-bordered w-full"
 						>
 							<option value="">Select a teacher</option>
-							{teachers?.map((teacher) => (
-								<option key={teacher.id} value={teacher.id}>
-									{teacher.firstName} {teacher.lastName}
-								</option>
-							))}
+                                                        {teachers?.map((teacher) => (
+                                                                <option key={teacher.id} value={teacher.id}>
+                                                                        {teacher.name}
+                                                                </option>
+                                                        ))}
 						</select>
 						{errors.defaultTeacher && (
 							<label className="label">

--- a/apps/web/src/pages/teacher/ClassCourseManagement.tsx
+++ b/apps/web/src/pages/teacher/ClassCourseManagement.tsx
@@ -41,10 +41,9 @@ interface Program {
 }
 
 interface Teacher {
-	id: string;
-	firstName: string;
-	lastName: string;
-	role: string;
+        id: string;
+        name: string;
+        role: string | null;
 }
 
 export default function ClassCourseManagement() {
@@ -95,7 +94,11 @@ export default function ClassCourseManagement() {
         const { data: teachers } = useQuery({
                 queryKey: ["teachers"],
                 queryFn: async () => {
-                        return [] as Teacher[];
+                        const { items } = await trpcClient.users.list.query({
+                                role: "teacher",
+                                limit: 100,
+                        });
+                        return items as Teacher[];
                 },
         });
 
@@ -119,9 +122,7 @@ export default function ClassCourseManagement() {
 	const classMap = new Map((classes ?? []).map((c) => [c.id, c]));
 	const courseMap = new Map((courses ?? []).map((c) => [c.id, c.name]));
 	const programMap = new Map((programs ?? []).map((p) => [p.id, p.name]));
-	const teacherMap = new Map(
-		(teachers ?? []).map((t) => [t.id, `${t.firstName} ${t.lastName}`]),
-	);
+        const teacherMap = new Map((teachers ?? []).map((t) => [t.id, t.name]));
 	const activeClassIds = new Set((classes ?? []).map((c) => c.id));
 	const displayedClassCourses = (classCourses ?? []).filter((cc) =>
 		activeClassIds.has(cc.class),
@@ -369,11 +370,11 @@ export default function ClassCourseManagement() {
 							className="select select-bordered w-full"
 						>
 							<option value="">Select a teacher</option>
-							{teachers?.map((teacher) => (
-								<option key={teacher.id} value={teacher.id}>
-									{teacher.firstName} {teacher.lastName}
-								</option>
-							))}
+                                                        {teachers?.map((teacher) => (
+                                                                <option key={teacher.id} value={teacher.id}>
+                                                                        {teacher.name}
+                                                                </option>
+                                                        ))}
 						</select>
 						{errors.teacher && (
 							<label className="label">

--- a/apps/web/src/pages/teacher/CourseManagement.tsx
+++ b/apps/web/src/pages/teacher/CourseManagement.tsx
@@ -34,10 +34,9 @@ interface Program {
 }
 
 interface Teacher {
-	id: string;
-	firstName: string;
-	lastName: string;
-	role: string;
+        id: string;
+        name: string;
+        role: string | null;
 }
 
 export default function CourseManagement() {
@@ -67,7 +66,11 @@ export default function CourseManagement() {
         const { data: teachers } = useQuery({
                 queryKey: ["teachers"],
                 queryFn: async () => {
-                        return [] as Teacher[];
+                        const { items } = await trpcClient.users.list.query({
+                                role: "teacher",
+                                limit: 100,
+                        });
+                        return items as Teacher[];
                 },
         });
 
@@ -81,9 +84,7 @@ export default function CourseManagement() {
 	});
 
 	const programMap = new Map((programs ?? []).map((p) => [p.id, p.name]));
-	const teacherMap = new Map(
-		(teachers ?? []).map((t) => [t.id, `${t.firstName} ${t.lastName}`]),
-	);
+        const teacherMap = new Map((teachers ?? []).map((t) => [t.id, t.name]));
 
 	const createMutation = useMutation({
 		mutationFn: async (data: CourseFormData) => {
@@ -332,11 +333,11 @@ export default function CourseManagement() {
 							className="select select-bordered w-full"
 						>
 							<option value="">Select a teacher</option>
-							{teachers?.map((teacher) => (
-								<option key={teacher.id} value={teacher.id}>
-									{teacher.firstName} {teacher.lastName}
-								</option>
-							))}
+                                                        {teachers?.map((teacher) => (
+                                                                <option key={teacher.id} value={teacher.id}>
+                                                                        {teacher.name}
+                                                                </option>
+                                                        ))}
 						</select>
 						{errors.defaultTeacher && (
 							<label className="label">


### PR DESCRIPTION
## Summary
- add users repository/service/router for paginated listing with optional role filter
- expose new users.list tRPC procedure and wire into app router
- fetch teachers via users.list in admin and teacher course/class management pages

## Testing
- `npx biome check apps/web/src/pages/admin/ClassCourseManagement.tsx apps/web/src/pages/admin/CourseManagement.tsx apps/web/src/pages/teacher/ClassCourseManagement.tsx apps/web/src/pages/teacher/CourseManagement.tsx` *(fails: lint warnings in multiple files)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_68c6c46bcf8083278d446f7cb33fb834