### PR TITLE
feat(admin): enhance user management UX

### DIFF
--- a/apps/web/src/hooks/useDebounce.ts
+++ b/apps/web/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay = 500) {
+	const [debounced, setDebounced] = useState(value);
+
+	useEffect(() => {
+		const handler = setTimeout(() => setDebounced(value), delay);
+		return () => clearTimeout(handler);
+	}, [value, delay]);
+
+	return debounced;
+}


### PR DESCRIPTION
## Summary
- add reusable `useDebounce` hook
- debounce user search and simplify actions with a dropdown
- allow admins to generate, show/hide, and copy passwords when creating users

## Testing
- `npx biome check apps/web/src/pages/admin/UserManagement.tsx apps/web/src/hooks/useDebounce.ts`
- `bun test` *(fails: relation "faculties" does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_68c71dc7f32883279301640615bbd514