### PR TITLE
feat: add user filters

### DIFF
--- a/apps/server/src/modules/users/users.repo.ts
+++ b/apps/server/src/modules/users/users.repo.ts
@@ -6,11 +6,21 @@ export async function list(opts: {
 	cursor?: string | null;
 	limit?: number;
 	role?: string;
+	banned?: boolean;
+	emailVerified?: boolean;
 }) {
 	const limit = Math.min(Math.max(opts.limit ?? 20, 1), 100);
 	let condition: SQL<unknown> | undefined;
 	if (opts.role) {
 		condition = eq(user.role, opts.role);
+	}
+	if (opts.banned !== undefined) {
+		const bannedCond = eq(user.banned, opts.banned);
+		condition = condition ? and(condition, bannedCond) : bannedCond;
+	}
+	if (opts.emailVerified !== undefined) {
+		const emailCond = eq(user.emailVerified, opts.emailVerified);
+		condition = condition ? and(condition, emailCond) : emailCond;
 	}
 	if (opts.cursor) {
 		const cursorCond = gt(user.id, opts.cursor);
@@ -22,6 +32,8 @@ export async function list(opts: {
 			name: user.name,
 			email: user.email,
 			role: user.role,
+			banned: user.banned,
+			emailVerified: user.emailVerified,
 			createdAt: user.createdAt,
 		})
 		.from(user)

--- a/apps/server/src/modules/users/users.router.ts
+++ b/apps/server/src/modules/users/users.router.ts
@@ -6,6 +6,8 @@ const listSchema = z.object({
 	cursor: z.string().nullish(),
 	limit: z.number().min(1).max(100).optional(),
 	role: z.string().optional(),
+	banned: z.boolean().optional(),
+	emailVerified: z.boolean().optional(),
 });
 
 export const usersRouter = router({


### PR DESCRIPTION
## Summary
- enable role, ban, and email verification filters on user listing
- display verification and ban status badges in admin table

## Testing
- `bunx biome check apps/server/src/modules/users/users.router.ts apps/server/src/modules/users/users.repo.ts apps/web/src/pages/admin/UserManagement.tsx`
- `bun run check-types` *(fails: Property 'getSQL' is missing in type '{}' but required in type 'SQLWrapper')*
- `bun run build` *(web)*

------
https://chatgpt.com/codex/tasks/task_b_68c7ba229acc832781476ab7980edaf5