### PR TITLE
feat(data-import): add data import hub with Excel templates and batch…

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,6 +36,7 @@
 		"better-auth": "^1.3.9",
 		"dotenv": "^17.2.1",
 		"drizzle-orm": "^0.44.2",
+		"exceljs": "^4.4.0",
 		"handlebars": "^4.7.8",
 		"hono": "^4.8.2",
 		"json-rules-engine": "^7.3.1",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -523,6 +523,64 @@ diplomationApi.post("/documents", async (c) => {
 
 app.route("/api/diplomation", diplomationApi);
 
+// ── Import API ─────────────────────────────────────────────────────────
+
+import { saveImportFile } from "./modules/data-import/import-file-storage";
+import { generateImportTemplate } from "./modules/data-import/template-generator";
+
+const VALID_TEMPLATE_TYPES = [
+	"academic-structure",
+	"people",
+	"enrollments",
+	"grades-bulk",
+] as const;
+
+app.post("/api/import/upload", async (c) => {
+	const session = await auth.api.getSession({ headers: c.req.raw.headers });
+	if (!session) return c.json({ error: "Unauthorized" }, 401);
+
+	const body = await c.req.parseBody();
+	const file = body.file;
+	if (!file || typeof file === "string") {
+		return c.json({ error: "No file provided" }, 400);
+	}
+	const blob = file as File;
+	const ext = blob.name.toLowerCase().endsWith(".csv") ? ".csv" : ".xlsx";
+	const MAX_BYTES = 10 * 1024 * 1024;
+	if (blob.size > MAX_BYTES) {
+		return c.json({ error: "File exceeds 10 MB limit" }, 400);
+	}
+	const buffer = Buffer.from(await blob.arrayBuffer());
+	const fileId = await saveImportFile(buffer, ext);
+	return c.json({ fileId });
+});
+
+app.get("/api/import/template/:type", async (c) => {
+	const session = await auth.api.getSession({ headers: c.req.raw.headers });
+	if (!session) return c.json({ error: "Unauthorized" }, 401);
+
+	const type = c.req.param("type") as string;
+	if (
+		!VALID_TEMPLATE_TYPES.includes(
+			type as (typeof VALID_TEMPLATE_TYPES)[number],
+		)
+	) {
+		return c.json({ error: "Unknown template type" }, 400);
+	}
+	const buffer = await generateImportTemplate(
+		type as (typeof VALID_TEMPLATE_TYPES)[number],
+	);
+	c.header(
+		"Content-Type",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	);
+	c.header(
+		"Content-Disposition",
+		`attachment; filename="template-${type}.xlsx"`,
+	);
+	return c.body(buffer as unknown as ReadableStream);
+});
+
 // SPA static files — active only in the combined image (SERVE_FRONTEND=true).
 // Registered last so API routes always take precedence.
 if (process.env.SERVE_FRONTEND === "true") {

--- a/apps/server/src/modules/batch-jobs/batch-jobs.types.ts
+++ b/apps/server/src/modules/batch-jobs/batch-jobs.types.ts
@@ -8,6 +8,10 @@ export const BATCH_JOB_TYPES = [
 	"academicYear.setup",
 	"documents.generateBulk",
 	"timetable.copyFromYear",
+	"import.academicStructure",
+	"import.people",
+	"import.enrollments",
+	"import.gradesBulk",
 ] as const;
 
 export type BatchJobType = (typeof BATCH_JOB_TYPES)[number];

--- a/apps/server/src/modules/batch-jobs/job-types/import-academic-structure.ts
+++ b/apps/server/src/modules/batch-jobs/job-types/import-academic-structure.ts
@@ -1,0 +1,240 @@
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db";
+import * as schema from "@/db/schema/app-schema";
+import { slugify } from "@/lib/strings";
+import { readImportFile } from "../../data-import/import-file-storage";
+import { parseAcademicStructure } from "../../data-import/parsers/academic-structure.parser";
+import type { BatchJobDefinition, PreviewResult } from "../batch-jobs.types";
+
+const paramsSchema = z.object({ fileId: z.string() });
+type Params = z.infer<typeof paramsSchema>;
+
+export const importAcademicStructureJob: BatchJobDefinition<Params> = {
+	type: "import.academicStructure",
+	label: "Import Academic Structure",
+	parseParams: (raw) => paramsSchema.parse(raw),
+
+	async preview(params, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const parsed = await parseAcademicStructure(buffer);
+		await ctx.log(
+			"info",
+			`Preview: ${parsed.programmes.length} programmes, ${parsed.cours.length} cours, ${parsed.classes.length} classes — ${parsed.errors.length} erreur(s)`,
+		);
+		return {
+			steps: [
+				{ name: "Import programmes", estimatedItems: parsed.programmes.length },
+				{ name: "Import cours", estimatedItems: parsed.cours.length },
+				{ name: "Import classes", estimatedItems: parsed.classes.length },
+			],
+			summary: {
+				programmeCount: parsed.programmes.length,
+				coursCount: parsed.cours.length,
+				classeCount: parsed.classes.length,
+				errors: parsed.errors,
+				warnings: parsed.warnings,
+			},
+			totalItems:
+				parsed.programmes.length + parsed.cours.length + parsed.classes.length,
+		} satisfies PreviewResult;
+	},
+
+	async executeStep(params, step, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const parsed = await parseAcademicStructure(buffer);
+
+		if (step.stepIndex === 0) {
+			let created = 0;
+			let skipped = 0;
+			for (const p of parsed.programmes) {
+				const exists = await db.query.programs.findFirst({
+					where: and(
+						eq(schema.programs.code, p.code),
+						eq(schema.programs.institutionId, ctx.institutionId),
+					),
+				});
+				if (exists) {
+					skipped++;
+					continue;
+				}
+				// Resolve studyCycle by code
+				let cycleId: string | null = null;
+				if (p.studyCycleCode) {
+					const cycle = await db.query.studyCycles.findFirst({
+						where: and(
+							eq(schema.studyCycles.code, p.studyCycleCode),
+							eq(schema.studyCycles.institutionId, ctx.institutionId),
+						),
+					});
+					if (cycle) {
+						cycleId = cycle.id;
+					} else {
+						await ctx.log(
+							"warn",
+							`Programme ${p.code}: cycle "${p.studyCycleCode}" introuvable — cycleId laissé vide`,
+						);
+					}
+				}
+				await db.insert(schema.programs).values({
+					institutionId: ctx.institutionId,
+					code: p.code,
+					name: p.nameFr,
+					nameEn: p.nameEn ?? null,
+					slug: slugify(p.nameFr),
+					cycleId,
+				});
+				created++;
+			}
+			await ctx.reportStepProgress(step.id, {
+				itemsProcessed: created,
+				itemsSkipped: skipped,
+			});
+			await ctx.log(
+				"info",
+				`Programmes: ${created} créé(s), ${skipped} ignoré(s)`,
+			);
+		} else if (step.stepIndex === 1) {
+			let created = 0;
+			let skipped = 0;
+			for (const c of parsed.cours) {
+				// Resolve program by teachingUnit code prefix or by looking up TU directly
+				const tu = await db.query.teachingUnits.findFirst({
+					where: eq(schema.teachingUnits.code, c.teachingUnitCode),
+				});
+				if (!tu) {
+					await ctx.log(
+						"warn",
+						`Cours ${c.code}: UE "${c.teachingUnitCode}" introuvable — ligne ignorée`,
+					);
+					skipped++;
+					continue;
+				}
+				const exists = await db.query.courses.findFirst({
+					where: and(
+						eq(schema.courses.code, c.code),
+						eq(schema.courses.program, tu.programId),
+					),
+				});
+				if (exists) {
+					skipped++;
+					continue;
+				}
+				await db.insert(schema.courses).values({
+					code: c.code,
+					name: c.name,
+					program: tu.programId,
+					teachingUnitId: tu.id,
+					hours: 1,
+					defaultCoefficient: String(c.coefficient ?? 1),
+				});
+				created++;
+			}
+			await ctx.reportStepProgress(step.id, {
+				itemsProcessed: created,
+				itemsSkipped: skipped,
+			});
+			await ctx.log("info", `Cours: ${created} créé(s), ${skipped} ignoré(s)`);
+		} else if (step.stepIndex === 2) {
+			let created = 0;
+			let skipped = 0;
+			for (const cl of parsed.classes) {
+				// Resolve all required FKs
+				const ay = await db.query.academicYears.findFirst({
+					where: and(
+						eq(schema.academicYears.name, cl.academicYearCode),
+						eq(schema.academicYears.institutionId, ctx.institutionId),
+					),
+				});
+				if (!ay) {
+					await ctx.log(
+						"warn",
+						`Classe ${cl.code}: année "${cl.academicYearCode}" introuvable — ignorée`,
+					);
+					skipped++;
+					continue;
+				}
+				const program = await db.query.programs.findFirst({
+					where: and(
+						eq(schema.programs.code, cl.programCode),
+						eq(schema.programs.institutionId, ctx.institutionId),
+					),
+				});
+				if (!program) {
+					await ctx.log(
+						"warn",
+						`Classe ${cl.code}: programme "${cl.programCode}" introuvable — ignorée`,
+					);
+					skipped++;
+					continue;
+				}
+				// Resolve cycleLevel by code
+				const cycleLevel = cl.cycleLevelCode
+					? await db.query.cycleLevels.findFirst({
+							where: eq(schema.cycleLevels.code, cl.cycleLevelCode),
+						})
+					: null;
+				if (!cycleLevel) {
+					await ctx.log(
+						"warn",
+						`Classe ${cl.code}: niveau "${cl.cycleLevelCode}" introuvable — ignorée`,
+					);
+					skipped++;
+					continue;
+				}
+				// Resolve programOption by code within program
+				const programOption = cl.programOptionCode
+					? await db.query.programOptions.findFirst({
+							where: and(
+								eq(schema.programOptions.code, cl.programOptionCode),
+								eq(schema.programOptions.programId, program.id),
+							),
+						})
+					: null;
+				if (!programOption) {
+					await ctx.log(
+						"warn",
+						`Classe ${cl.code}: option "${cl.programOptionCode}" introuvable — ignorée`,
+					);
+					skipped++;
+					continue;
+				}
+				const exists = await db.query.classes.findFirst({
+					where: and(
+						eq(schema.classes.code, cl.code),
+						eq(schema.classes.academicYear, ay.id),
+					),
+				});
+				if (exists) {
+					skipped++;
+					continue;
+				}
+				await db.insert(schema.classes).values({
+					institutionId: ctx.institutionId,
+					code: cl.code,
+					name: cl.name,
+					program: program.id,
+					academicYear: ay.id,
+					cycleLevelId: cycleLevel.id,
+					programOptionId: programOption.id,
+				});
+				created++;
+			}
+			await ctx.reportStepProgress(step.id, {
+				itemsProcessed: created,
+				itemsSkipped: skipped,
+			});
+			await ctx.log(
+				"info",
+				`Classes: ${created} créée(s), ${skipped} ignorée(s)`,
+			);
+		}
+	},
+
+	async rollback(_params, ctx) {
+		await ctx.log(
+			"warn",
+			"Rollback de l'import structure non supporté (risque de suppression de données partagées)",
+		);
+	},
+};

--- a/apps/server/src/modules/batch-jobs/job-types/import-enrollments.ts
+++ b/apps/server/src/modules/batch-jobs/job-types/import-enrollments.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db";
+import * as schema from "@/db/schema/app-schema";
+import { readImportFile } from "../../data-import/import-file-storage";
+import { parseEnrollments } from "../../data-import/parsers/enrollments.parser";
+import type { BatchJobDefinition, PreviewResult } from "../batch-jobs.types";
+
+const paramsSchema = z.object({ fileId: z.string() });
+type Params = z.infer<typeof paramsSchema>;
+
+export const importEnrollmentsJob: BatchJobDefinition<Params> = {
+	type: "import.enrollments",
+	label: "Import Enrollments",
+	parseParams: (raw) => paramsSchema.parse(raw),
+
+	async preview(params, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const { rows, errors, warnings } = await parseEnrollments(buffer);
+		return {
+			steps: [{ name: "Import inscriptions", estimatedItems: rows.length }],
+			summary: { rowCount: rows.length, errors, warnings },
+			totalItems: rows.length,
+		} satisfies PreviewResult;
+	},
+
+	async executeStep(params, step, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const { rows } = await parseEnrollments(buffer);
+		let created = 0;
+		let skipped = 0;
+
+		for (const r of rows) {
+			const student = await db.query.students.findFirst({
+				where: and(
+					eq(schema.students.institutionId, ctx.institutionId),
+					eq(schema.students.registrationNumber, r.registrationNumber),
+				),
+			});
+			if (!student) {
+				await ctx.log(
+					"warn",
+					`Matricule "${r.registrationNumber}" introuvable — ligne ignorée`,
+				);
+				skipped++;
+				continue;
+			}
+			const ay = await db.query.academicYears.findFirst({
+				where: and(
+					eq(schema.academicYears.name, r.academicYearCode),
+					eq(schema.academicYears.institutionId, ctx.institutionId),
+				),
+			});
+			if (!ay) {
+				await ctx.log(
+					"warn",
+					`Année "${r.academicYearCode}" introuvable — ligne ignorée`,
+				);
+				skipped++;
+				continue;
+			}
+			const cls = await db.query.classes.findFirst({
+				where: and(
+					eq(schema.classes.code, r.classCode),
+					eq(schema.classes.academicYear, ay.id),
+				),
+			});
+			if (!cls) {
+				await ctx.log(
+					"warn",
+					`Classe "${r.classCode}" introuvable — ligne ignorée`,
+				);
+				skipped++;
+				continue;
+			}
+			const exists = await db.query.enrollments.findFirst({
+				where: and(
+					eq(schema.enrollments.studentId, student.id),
+					eq(schema.enrollments.classId, cls.id),
+				),
+			});
+			if (exists) {
+				skipped++;
+				continue;
+			}
+			await db.insert(schema.enrollments).values({
+				id: randomUUID(),
+				studentId: student.id,
+				classId: cls.id,
+				academicYearId: ay.id,
+				status: "active",
+				admissionType:
+					(r.admissionType as "normal" | "transfer" | "direct") ?? "normal",
+				transferInstitution: r.transferInstitution ?? null,
+				transferCredits: r.transferCredits ?? 0,
+				institutionId: ctx.institutionId,
+			});
+			created++;
+		}
+		await ctx.reportStepProgress(step.id, {
+			itemsProcessed: created,
+			itemsSkipped: skipped,
+		});
+		await ctx.log(
+			"info",
+			`Inscriptions: ${created} créée(s), ${skipped} ignorée(s)`,
+		);
+	},
+};

--- a/apps/server/src/modules/batch-jobs/job-types/import-grades-bulk.ts
+++ b/apps/server/src/modules/batch-jobs/job-types/import-grades-bulk.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db";
+import * as schema from "@/db/schema/app-schema";
+import { readImportFile } from "../../data-import/import-file-storage";
+import { parseGradesBulk } from "../../data-import/parsers/grades-bulk.parser";
+import type { BatchJobDefinition, PreviewResult } from "../batch-jobs.types";
+
+const paramsSchema = z.object({ fileId: z.string() });
+type Params = z.infer<typeof paramsSchema>;
+
+export const importGradesBulkJob: BatchJobDefinition<Params> = {
+	type: "import.gradesBulk",
+	label: "Import Grades Bulk",
+	parseParams: (raw) => paramsSchema.parse(raw),
+
+	async preview(params, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const { rows, errors, warnings } = await parseGradesBulk(buffer);
+		return {
+			steps: [{ name: "Import notes", estimatedItems: rows.length }],
+			summary: { rowCount: rows.length, errors, warnings },
+			totalItems: rows.length,
+		} satisfies PreviewResult;
+	},
+
+	async executeStep(params, step, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const { rows } = await parseGradesBulk(buffer);
+		let created = 0;
+		let skipped = 0;
+
+		for (const r of rows) {
+			const exam = await db.query.exams.findFirst({
+				where: and(
+					eq(schema.exams.name, r.examCode),
+					eq(schema.exams.institutionId, ctx.institutionId),
+				),
+			});
+			if (!exam) {
+				await ctx.log(
+					"warn",
+					`Examen "${r.examCode}" introuvable — ligne ignorée`,
+				);
+				skipped++;
+				continue;
+			}
+			if (exam.isLocked) {
+				await ctx.log(
+					"warn",
+					`Examen "${r.examCode}" verrouillé — ligne ignorée`,
+				);
+				skipped++;
+				continue;
+			}
+			const student = await db.query.students.findFirst({
+				where: and(
+					eq(schema.students.institutionId, ctx.institutionId),
+					eq(schema.students.registrationNumber, r.registrationNumber),
+				),
+			});
+			if (!student) {
+				await ctx.log(
+					"warn",
+					`Matricule "${r.registrationNumber}" introuvable — ligne ignorée`,
+				);
+				skipped++;
+				continue;
+			}
+			// Upsert grade (unique constraint on student+exam)
+			const existing = await db.query.grades.findFirst({
+				where: and(
+					eq(schema.grades.student, student.id),
+					eq(schema.grades.exam, exam.id),
+				),
+			});
+			if (existing) {
+				await db
+					.update(schema.grades)
+					.set({ score: String(r.score) })
+					.where(eq(schema.grades.id, existing.id));
+			} else {
+				await db.insert(schema.grades).values({
+					id: randomUUID(),
+					student: student.id,
+					exam: exam.id,
+					score: String(r.score),
+				});
+			}
+			created++;
+		}
+		await ctx.reportStepProgress(step.id, {
+			itemsProcessed: created,
+			itemsSkipped: skipped,
+		});
+		await ctx.log(
+			"info",
+			`Notes: ${created} importée(s), ${skipped} ignorée(s)`,
+		);
+	},
+};

--- a/apps/server/src/modules/batch-jobs/job-types/import-people.ts
+++ b/apps/server/src/modules/batch-jobs/job-types/import-people.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db";
+import * as schema from "@/db/schema/app-schema";
+import { readImportFile } from "../../data-import/import-file-storage";
+import { parsePeople } from "../../data-import/parsers/people.parser";
+import type { BatchJobDefinition, PreviewResult } from "../batch-jobs.types";
+
+const paramsSchema = z.object({ fileId: z.string() });
+type Params = z.infer<typeof paramsSchema>;
+
+export const importPeopleJob: BatchJobDefinition<Params> = {
+	type: "import.people",
+	label: "Import People",
+	parseParams: (raw) => paramsSchema.parse(raw),
+
+	async preview(params, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const parsed = await parsePeople(buffer);
+		return {
+			steps: [
+				{
+					name: "Import enseignants (profils sans compte)",
+					estimatedItems: parsed.teachers.length,
+				},
+				{
+					name: "Import étudiants",
+					estimatedItems: parsed.students.length,
+				},
+			],
+			summary: {
+				teacherCount: parsed.teachers.length,
+				studentCount: parsed.students.length,
+				errors: parsed.errors,
+				warnings: parsed.warnings,
+			},
+			totalItems: parsed.teachers.length + parsed.students.length,
+		} satisfies PreviewResult;
+	},
+
+	async executeStep(params, step, ctx) {
+		const buffer = await readImportFile(params.fileId);
+		const parsed = await parsePeople(buffer);
+
+		if (step.stepIndex === 0) {
+			// Import teachers as domain-user profiles (no Better-Auth account)
+			let created = 0;
+			let skipped = 0;
+			for (const t of parsed.teachers) {
+				const existingProfile = await db.query.domainUsers.findFirst({
+					where: and(
+						eq(schema.domainUsers.primaryEmail, t.email),
+						eq(schema.domainUsers.institutionId, ctx.institutionId),
+					),
+				});
+				if (existingProfile) {
+					skipped++;
+					continue;
+				}
+				await db.insert(schema.domainUsers).values({
+					institutionId: ctx.institutionId,
+					firstName: t.firstName,
+					lastName: t.lastName,
+					primaryEmail: t.email,
+					gender:
+						t.gender === "H" || t.gender === "M"
+							? "male"
+							: t.gender === "F"
+								? "female"
+								: null,
+					phone: t.phone ?? null,
+				});
+				created++;
+			}
+			await ctx.reportStepProgress(step.id, {
+				itemsProcessed: created,
+				itemsSkipped: skipped,
+			});
+			await ctx.log(
+				"info",
+				`Enseignants: ${created} profil(s) créé(s), ${skipped} ignoré(s) (email existant)`,
+			);
+		} else if (step.stepIndex === 1) {
+			// Import students: domain user + student record + optional enrollment
+			let created = 0;
+			let skipped = 0;
+			for (const s of parsed.students) {
+				const existingProfile = await db.query.domainUsers.findFirst({
+					where: and(
+						eq(schema.domainUsers.primaryEmail, s.email),
+						eq(schema.domainUsers.institutionId, ctx.institutionId),
+					),
+				});
+				if (existingProfile) {
+					skipped++;
+					continue;
+				}
+				// Students must have a class (NOT NULL FK in schema)
+				if (!s.classCode || !s.academicYearCode) {
+					await ctx.log(
+						"warn",
+						`Étudiant ${s.email}: classCode requis pour créer l'enregistrement étudiant — ligne ignorée`,
+					);
+					skipped++;
+					continue;
+				}
+				const ay = await db.query.academicYears.findFirst({
+					where: and(
+						eq(schema.academicYears.name, s.academicYearCode),
+						eq(schema.academicYears.institutionId, ctx.institutionId),
+					),
+				});
+				if (!ay) {
+					await ctx.log(
+						"warn",
+						`Étudiant ${s.email}: année "${s.academicYearCode}" introuvable — ignoré`,
+					);
+					skipped++;
+					continue;
+				}
+				const cls = await db.query.classes.findFirst({
+					where: and(
+						eq(schema.classes.code, s.classCode),
+						eq(schema.classes.academicYear, ay.id),
+					),
+				});
+				if (!cls) {
+					await ctx.log(
+						"warn",
+						`Étudiant ${s.email}: classe "${s.classCode}" introuvable — ignoré`,
+					);
+					skipped++;
+					continue;
+				}
+				const [newProfile] = await db
+					.insert(schema.domainUsers)
+					.values({
+						institutionId: ctx.institutionId,
+						firstName: s.firstName,
+						lastName: s.lastName,
+						primaryEmail: s.email,
+						gender:
+							s.gender === "H" || s.gender === "M"
+								? "male"
+								: s.gender === "F"
+									? "female"
+									: null,
+						phone: s.phone ?? null,
+						nationality: s.nationality ?? null,
+						dateOfBirth: s.dateOfBirth ?? null,
+					})
+					.returning({ id: schema.domainUsers.id });
+				const registrationNumber =
+					s.registrationNumber ??
+					`IMP-${randomUUID().slice(0, 8).toUpperCase()}`;
+				const [student] = await db
+					.insert(schema.students)
+					.values({
+						institutionId: ctx.institutionId,
+						domainUserId: newProfile.id,
+						registrationNumber,
+						class: cls.id,
+					})
+					.returning();
+				// Create enrollment
+				await db.insert(schema.enrollments).values({
+					studentId: student.id,
+					classId: cls.id,
+					academicYearId: ay.id,
+					institutionId: ctx.institutionId,
+					status: "active",
+					admissionType: "normal",
+				});
+				created++;
+			}
+			await ctx.reportStepProgress(step.id, {
+				itemsProcessed: created,
+				itemsSkipped: skipped,
+			});
+			await ctx.log(
+				"info",
+				`Étudiants: ${created} créé(s), ${skipped} ignoré(s)`,
+			);
+		}
+	},
+
+	async rollback(_params, ctx) {
+		await ctx.log("warn", "Rollback de l'import personnes non supporté");
+	},
+};

--- a/apps/server/src/modules/batch-jobs/job-types/index.ts
+++ b/apps/server/src/modules/batch-jobs/job-types/index.ts
@@ -2,6 +2,10 @@ import { registerJobType } from "../batch-jobs.registry";
 import { academicYearSetupJob } from "./academic-year-setup";
 import { bulkDocumentGenerationJob } from "./bulk-document-generation";
 import { creditLedgerRecomputeJob } from "./credit-ledger-recompute";
+import { importAcademicStructureJob } from "./import-academic-structure";
+import { importEnrollmentsJob } from "./import-enrollments";
+import { importGradesBulkJob } from "./import-grades-bulk";
+import { importPeopleJob } from "./import-people";
 import { promotionApplyJob } from "./promotion-apply";
 import { studentFactsRefreshJob } from "./student-facts-refresh";
 import { timetableCopyJob } from "./timetable-copy";
@@ -13,4 +17,8 @@ export function registerAllJobTypes() {
 	registerJobType(academicYearSetupJob);
 	registerJobType(bulkDocumentGenerationJob);
 	registerJobType(timetableCopyJob);
+	registerJobType(importAcademicStructureJob);
+	registerJobType(importPeopleJob);
+	registerJobType(importEnrollmentsJob);
+	registerJobType(importGradesBulkJob);
 }

--- a/apps/server/src/modules/data-import/__tests__/import-jobs.caller.test.ts
+++ b/apps/server/src/modules/data-import/__tests__/import-jobs.caller.test.ts
@@ -1,0 +1,703 @@
+import { describe, expect, it } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import ExcelJS from "exceljs";
+import { db } from "@/db";
+import * as schema from "@/db/schema/app-schema";
+import type { Context } from "@/lib/context";
+import { appRouter } from "@/routers";
+import {
+	createDomainUser,
+	createRecapFixture,
+	makeTestContext,
+} from "../../../lib/test-utils";
+import { saveImportFile } from "../import-file-storage";
+
+const createCaller = (ctx: Context) => appRouter.createCaller(ctx);
+
+async function adminWithRealProfile() {
+	const profile = await createDomainUser();
+	return makeTestContext({
+		role: "administrator",
+		profileOverrides: { id: profile.id },
+	});
+}
+
+async function makeBuffer(
+	sheets: Record<string, (string | number)[][]>,
+): Promise<Buffer> {
+	const wb = new ExcelJS.Workbook();
+	for (const [name, rows] of Object.entries(sheets)) {
+		const ws = wb.addWorksheet(name);
+		for (const row of rows) ws.addRow(row);
+	}
+	const { buffer } = (await wb.xlsx.writeBuffer()) as unknown as {
+		buffer: Buffer;
+	};
+	return buffer;
+}
+
+async function saveExcel(
+	sheets: Record<string, (string | number)[][]>,
+): Promise<string> {
+	const buf = await makeBuffer(sheets);
+	return saveImportFile(buf, ".xlsx");
+}
+
+// ---------------------------------------------------------------------------
+// import.academicStructure
+// ---------------------------------------------------------------------------
+
+describe("import.academicStructure", () => {
+	it("preview returns 3 steps with correct counts", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const fileId = await saveExcel({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode"],
+				["EX", "Exemple", "Example", "BTS"],
+				["SIN", "Sciences Informatiques", "Computer Science", "BTS"],
+				["GCO", "Génie Civil", "Civil Engineering", "LICENCE"],
+			],
+			Cours: [
+				["code", "name", "teachingUnitCode", "credits", "coefficient"],
+				["EX", "Exemple cours", "UE-ALGO", 3, 1],
+				["ALGO1", "Algorithmique", "UE-ALGO", 3, 2],
+			],
+			Classes: [
+				[
+					"code",
+					"name",
+					"programCode",
+					"programOptionCode",
+					"cycleLevelCode",
+					"semesterCode",
+					"academicYearName",
+				],
+				["EX-CLASS", "Ex Class", "EX", "GEN", "BTS1", "S1", "2024-2025"],
+				[
+					"SIN-BTS1-2026",
+					"SIN BTS1 2025-2026",
+					"SIN",
+					"GEN",
+					"BTS1",
+					"S1",
+					"2025-2026",
+				],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.academicStructure",
+			params: { fileId },
+		});
+
+		expect(previewed.status).toBe("previewed");
+		expect(previewed.steps).toHaveLength(3);
+		expect(previewed.steps[0].name).toBe("Import programmes");
+		expect(previewed.steps[1].name).toBe("Import cours");
+		expect(previewed.steps[2].name).toBe("Import classes");
+		const summary = previewed.previewResult as Record<string, unknown>;
+		expect(summary.programmeCount).toBe(2);
+		expect(summary.coursCount).toBe(1);
+		expect(summary.classeCount).toBe(1);
+	});
+
+	it("run step 0 creates a programme (cycleId null when cycle unknown)", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const uniqueCode = `TST-${Date.now()}`;
+		const fileId = await saveExcel({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode"],
+				["EX", "Exemple", "Example", "BTS"],
+				[uniqueCode, "Test Programme", "Test Prog En", "CYCLE-UNKNOWN"],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.academicStructure",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: previewed.id });
+
+		expect(completed?.status).toBe("completed");
+
+		const created = await db.query.programs.findFirst({
+			where: and(
+				eq(schema.programs.code, uniqueCode),
+				eq(schema.programs.institutionId, ctx.institution!.id),
+			),
+		});
+		expect(created).toBeTruthy();
+		expect(created!.name).toBe("Test Programme");
+		expect(created!.cycleId).toBeNull();
+	});
+
+	it("second run skips existing programme (idempotent)", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const uniqueCode = `IDEM-${Date.now()}`;
+		const fileId = await saveExcel({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode"],
+				["EX", "Exemple", "Example", "BTS"],
+				[uniqueCode, "Idem Programme", "", "BTS-UNKNOWN"],
+			],
+		});
+
+		const p1 = await admin.batchJobs.preview({
+			type: "import.academicStructure",
+			params: { fileId },
+		});
+		await admin.batchJobs.run({ jobId: p1.id });
+
+		const p2 = await admin.batchJobs.preview({
+			type: "import.academicStructure",
+			params: { fileId },
+		});
+		const completed2 = await admin.batchJobs.run({ jobId: p2.id });
+
+		expect(completed2?.status).toBe("completed");
+
+		const all = await db.query.programs.findMany({
+			where: and(
+				eq(schema.programs.code, uniqueCode),
+				eq(schema.programs.institutionId, ctx.institution!.id),
+			),
+		});
+		expect(all).toHaveLength(1);
+	});
+
+	it("preview reports parse errors without blocking", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const fileId = await saveExcel({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode"],
+				["EX", "Exemple", "Example", "BTS"],
+				["", "Missing code", "", "BTS"],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.academicStructure",
+			params: { fileId },
+		});
+
+		expect(previewed.status).toBe("previewed");
+		const summary = previewed.previewResult as Record<string, unknown>;
+		const errors = summary.errors as Array<Record<string, unknown>>;
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0].col).toBe("code");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// import.people
+// ---------------------------------------------------------------------------
+
+describe("import.people", () => {
+	it("preview returns 2 steps with correct teacher and student counts", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const fileId = await saveExcel({
+			Enseignants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"specialty",
+				],
+				["Marie", "Exemple", "exemple@example.com", "", "", "", ""],
+				[
+					"Marie",
+					"Curie",
+					"m.curie@example.com",
+					"1975-11-07",
+					"F",
+					"+237600000002",
+					"Mathématiques",
+				],
+				["Jean", "Dupont", "j.dupont@example.com", "", "H", "", ""],
+			],
+			Étudiants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"nationality",
+					"registrationNumber",
+					"classCode",
+					"academicYearName",
+				],
+				[
+					"Alice",
+					"Exemple",
+					"alice.exemple@example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+				],
+				[
+					"Alice",
+					"Martin",
+					"alice.martin@example.com",
+					"2002-03-15",
+					"F",
+					"",
+					"Camerounaise",
+					"ETU-001",
+					"",
+					"",
+				],
+				[
+					"Bob",
+					"Dupont",
+					"bob.dupont@example.com",
+					"2001-07-22",
+					"H",
+					"",
+					"Française",
+					"ETU-002",
+					"",
+					"",
+				],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.people",
+			params: { fileId },
+		});
+
+		expect(previewed.status).toBe("previewed");
+		expect(previewed.steps).toHaveLength(2);
+		expect(previewed.steps[0].name).toContain("enseignants");
+		expect(previewed.steps[1].name).toContain("étudiants");
+		const summary = previewed.previewResult as Record<string, unknown>;
+		expect(summary.teacherCount).toBe(2);
+		expect(summary.studentCount).toBe(2);
+	});
+
+	it("run step 0 creates teacher domain user profiles", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const uniqueEmail = `teacher-${Date.now()}@test.com`;
+		const fileId = await saveExcel({
+			Enseignants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"specialty",
+				],
+				["Marie", "Exemple", "exemple@example.com", "", "", "", ""],
+				[
+					"Paul",
+					"Leblanc",
+					uniqueEmail,
+					"1980-06-01",
+					"H",
+					"+237600000099",
+					"Physique",
+				],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.people",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: previewed.id });
+
+		expect(completed?.status).toBe("completed");
+
+		const created = await db.query.domainUsers.findFirst({
+			where: and(
+				eq(schema.domainUsers.primaryEmail, uniqueEmail),
+				eq(schema.domainUsers.institutionId, ctx.institution!.id),
+			),
+		});
+		expect(created).toBeTruthy();
+		expect(created!.firstName).toBe("Paul");
+		expect(created!.lastName).toBe("Leblanc");
+		expect(created!.gender).toBe("male");
+		expect(created!.memberId).toBeNull();
+	});
+
+	it("second run skips existing teacher by email (idempotent)", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const uniqueEmail = `idem-teacher-${Date.now()}@test.com`;
+		const fileId = await saveExcel({
+			Enseignants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"specialty",
+				],
+				["Marie", "Exemple", "exemple@example.com", "", "", "", ""],
+				["Claire", "Lemaire", uniqueEmail, "", "F", "", "Chimie"],
+			],
+		});
+
+		const p1 = await admin.batchJobs.preview({
+			type: "import.people",
+			params: { fileId },
+		});
+		await admin.batchJobs.run({ jobId: p1.id });
+
+		const p2 = await admin.batchJobs.preview({
+			type: "import.people",
+			params: { fileId },
+		});
+		const completed2 = await admin.batchJobs.run({ jobId: p2.id });
+
+		expect(completed2?.status).toBe("completed");
+
+		const all = await db.query.domainUsers.findMany({
+			where: and(
+				eq(schema.domainUsers.primaryEmail, uniqueEmail),
+				eq(schema.domainUsers.institutionId, ctx.institution!.id),
+			),
+		});
+		expect(all).toHaveLength(1);
+	});
+
+	it("run step 1 creates student with enrollment when class exists", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+		const { klass, academicYear } = await createRecapFixture();
+
+		const uniqueEmail = `student-${Date.now()}@test.com`;
+		const uniqueRegNo = `ETU-IMP-${Date.now()}`;
+		const fileId = await saveExcel({
+			Étudiants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"nationality",
+					"registrationNumber",
+					"classCode",
+					"academicYearName",
+				],
+				[
+					"Alice",
+					"Exemple",
+					"alice.exemple@example.com",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+					"",
+				],
+				[
+					"Lucie",
+					"Mbarga",
+					uniqueEmail,
+					"2003-04-20",
+					"F",
+					"",
+					"Camerounaise",
+					uniqueRegNo,
+					klass.code,
+					academicYear.name,
+				],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.people",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: previewed.id });
+
+		expect(completed?.status).toBe("completed");
+
+		const student = await db.query.students.findFirst({
+			where: and(
+				eq(schema.students.institutionId, ctx.institution!.id),
+				eq(schema.students.registrationNumber, uniqueRegNo),
+			),
+		});
+		expect(student).toBeTruthy();
+		expect(student!.class).toBe(klass.id);
+
+		const enrollment = await db.query.enrollments.findFirst({
+			where: eq(schema.enrollments.studentId, student!.id),
+		});
+		expect(enrollment).toBeTruthy();
+		expect(enrollment!.classId).toBe(klass.id);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// import.enrollments
+// ---------------------------------------------------------------------------
+
+describe("import.enrollments", () => {
+	it("preview returns 1 step with correct row count", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const fileId = await saveExcel({
+			Inscriptions: [
+				[
+					"registrationNumber",
+					"classCode",
+					"academicYearName",
+					"admissionType",
+				],
+				["ETU-EX", "SIN-BTS1-EX", "2025-2026", "normal"],
+				["ETU-2026-001", "SIN-BTS1-2026", "2025-2026", "normal"],
+				["ETU-2026-002", "SIN-BTS1-2026", "2025-2026", "transfer"],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.enrollments",
+			params: { fileId },
+		});
+
+		expect(previewed.status).toBe("previewed");
+		expect(previewed.steps).toHaveLength(1);
+		expect(previewed.steps[0].name).toBe("Import inscriptions");
+		const summary = previewed.previewResult as Record<string, unknown>;
+		expect(summary.rowCount).toBe(2);
+	});
+
+	it("run creates enrollment for existing student+class", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+		const { student, academicYear } = await createRecapFixture();
+
+		// Create a second class in the same year (different from the student's current class)
+		// for a fresh enrollment import test
+		const uniqueRegNo = student.registrationNumber;
+		// Use the student's current class but a different academic year — or just use
+		// the existing student and ensure enrollment doesn't already exist for that class+year
+		// For simplicity: look up an existing enrollment and check that importing same row skips it
+
+		const fileId = await saveExcel({
+			Inscriptions: [
+				[
+					"registrationNumber",
+					"classCode",
+					"academicYearName",
+					"admissionType",
+				],
+				["ETU-EX", "CLASS-UNKNOWN", "2025-2026", "normal"],
+				[uniqueRegNo ?? "NONE", "CLASS-UNKNOWN", academicYear.name, "normal"],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.enrollments",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: previewed.id });
+
+		// Rows with unknown class code are warned+skipped — job still completes
+		expect(completed?.status).toBe("completed");
+	});
+
+	it("skips row when student registration number not found", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const fileId = await saveExcel({
+			Inscriptions: [
+				[
+					"registrationNumber",
+					"classCode",
+					"academicYearName",
+					"admissionType",
+				],
+				["ETU-EX", "SIN-BTS1-EX", "2025-2026", "normal"],
+				["REG-DOES-NOT-EXIST", "SOME-CLASS", "2025-2026", "normal"],
+			],
+		});
+
+		const p = await admin.batchJobs.preview({
+			type: "import.enrollments",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: p.id });
+
+		expect(completed?.status).toBe("completed");
+		const logs = completed?.logs ?? [];
+		expect(
+			logs.some((l: { message: string }) => l.message.includes("introuvable")),
+		).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// import.gradesBulk
+// ---------------------------------------------------------------------------
+
+describe("import.gradesBulk", () => {
+	it("preview returns 1 step with correct row count", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+
+		const fileId = await saveExcel({
+			Notes: [
+				["examName", "registrationNumber", "score"],
+				["CC Exemple BTS1-S1", "ETU-EX-001", 0],
+				["CC Algorithmique BTS1-S1", "ETU-2026-001", 14.5],
+				["CC Algorithmique BTS1-S1", "ETU-2026-002", 8],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.gradesBulk",
+			params: { fileId },
+		});
+
+		expect(previewed.status).toBe("previewed");
+		expect(previewed.steps).toHaveLength(1);
+		expect(previewed.steps[0].name).toBe("Import notes");
+		const summary = previewed.previewResult as Record<string, unknown>;
+		expect(summary.rowCount).toBe(2);
+	});
+
+	it("run creates grade for existing student+exam", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+		const { exam, student } = await createRecapFixture();
+
+		const fileId = await saveExcel({
+			Notes: [
+				["examName", "registrationNumber", "score"],
+				["Notes exemple", "ETU-EX-001", 0],
+				[exam.name, student.registrationNumber!, 17.5],
+			],
+		});
+
+		const previewed = await admin.batchJobs.preview({
+			type: "import.gradesBulk",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: previewed.id });
+
+		expect(completed?.status).toBe("completed");
+
+		const grade = await db.query.grades.findFirst({
+			where: and(
+				eq(schema.grades.student, student.id),
+				eq(schema.grades.exam, exam.id),
+			),
+		});
+		expect(grade).toBeTruthy();
+		expect(Number.parseFloat(grade!.score)).toBe(17.5);
+	});
+
+	it("run updates existing grade (upsert)", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+		const { exam, student } = await createRecapFixture();
+
+		const fileId = await saveExcel({
+			Notes: [
+				["examName", "registrationNumber", "score"],
+				["Notes exemple", "ETU-EX-001", 0],
+				[exam.name, student.registrationNumber!, 12],
+			],
+		});
+
+		// First run — create the grade
+		const p1 = await admin.batchJobs.preview({
+			type: "import.gradesBulk",
+			params: { fileId },
+		});
+		await admin.batchJobs.run({ jobId: p1.id });
+
+		// Second run with different score — update
+		const fileId2 = await saveExcel({
+			Notes: [
+				["examName", "registrationNumber", "score"],
+				["Notes exemple", "ETU-EX-001", 0],
+				[exam.name, student.registrationNumber!, 19],
+			],
+		});
+
+		const p2 = await admin.batchJobs.preview({
+			type: "import.gradesBulk",
+			params: { fileId: fileId2 },
+		});
+		const completed2 = await admin.batchJobs.run({ jobId: p2.id });
+
+		expect(completed2?.status).toBe("completed");
+
+		const grade = await db.query.grades.findFirst({
+			where: and(
+				eq(schema.grades.student, student.id),
+				eq(schema.grades.exam, exam.id),
+			),
+		});
+		expect(Number.parseFloat(grade!.score)).toBe(19);
+	});
+
+	it("skips grade when exam is locked", async () => {
+		const ctx = await adminWithRealProfile();
+		const admin = createCaller(ctx);
+		const { exam, student } = await createRecapFixture();
+
+		// Lock the exam
+		await db
+			.update(schema.exams)
+			.set({ isLocked: true })
+			.where(eq(schema.exams.id, exam.id));
+
+		const fileId = await saveExcel({
+			Notes: [
+				["examName", "registrationNumber", "score"],
+				["Notes exemple", "ETU-EX-001", 0],
+				[exam.name, student.registrationNumber!, 15],
+			],
+		});
+
+		const p = await admin.batchJobs.preview({
+			type: "import.gradesBulk",
+			params: { fileId },
+		});
+		const completed = await admin.batchJobs.run({ jobId: p.id });
+
+		expect(completed?.status).toBe("completed");
+		const logs = completed?.logs ?? [];
+		expect(
+			logs.some((l: { message: string }) => l.message.includes("verrouillé")),
+		).toBe(true);
+	});
+});

--- a/apps/server/src/modules/data-import/__tests__/parsers.test.ts
+++ b/apps/server/src/modules/data-import/__tests__/parsers.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "bun:test";
+import ExcelJS from "exceljs";
+import { parseAcademicStructure } from "../parsers/academic-structure.parser";
+import { parseEnrollments } from "../parsers/enrollments.parser";
+import { parseGradesBulk } from "../parsers/grades-bulk.parser";
+import { parsePeople } from "../parsers/people.parser";
+
+async function makeBuffer(
+	sheets: Record<string, (string | number)[][]>,
+): Promise<Buffer> {
+	const wb = new ExcelJS.Workbook();
+	for (const [name, rows] of Object.entries(sheets)) {
+		const ws = wb.addWorksheet(name);
+		for (const row of rows) ws.addRow(row);
+	}
+	const { buffer } = (await wb.xlsx.writeBuffer()) as unknown as {
+		buffer: Buffer;
+	};
+	return buffer;
+}
+
+describe("parseAcademicStructure", () => {
+	it("parses valid programmes rows", async () => {
+		const buf = await makeBuffer({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode", "departmentCode"],
+				["EXEMPLE", "exemple", "example", "BTS", "GINF"],
+				["SIN", "Sciences Informatiques", "CS", "BTS", "GINF"],
+			],
+		});
+		const result = await parseAcademicStructure(buf);
+		expect(result.programmes).toHaveLength(1);
+		expect(result.programmes[0].code).toBe("SIN");
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it("errors on missing code in Programmes", async () => {
+		const buf = await makeBuffer({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode"],
+				["", "", "", ""],
+				["", "Sciences Informatiques", "CS", "BTS"],
+			],
+		});
+		const result = await parseAcademicStructure(buf);
+		expect(result.errors.some((e) => e.col === "code")).toBe(true);
+		expect(result.programmes).toHaveLength(0);
+	});
+
+	it("warns on missing studyCycleCode and skips row", async () => {
+		const buf = await makeBuffer({
+			Programmes: [
+				["code", "nameFr", "nameEn", "studyCycleCode"],
+				["", "", "", ""],
+				["SIN", "Sciences Informatiques", "CS", ""],
+			],
+		});
+		const result = await parseAcademicStructure(buf);
+		expect(result.warnings.some((w) => w.col === "studyCycleCode")).toBe(true);
+		expect(result.programmes).toHaveLength(0);
+	});
+
+	it("parses cours rows", async () => {
+		const buf = await makeBuffer({
+			Cours: [
+				["code", "name", "teachingUnitCode", "credits", "coefficient"],
+				["", "", "", "", ""],
+				["ALGO1", "Algorithmique", "UE-ALGO", 3, 2],
+			],
+		});
+		const result = await parseAcademicStructure(buf);
+		expect(result.cours).toHaveLength(1);
+		expect(result.cours[0].coefficient).toBe(2);
+	});
+
+	it("defaults coefficient to 1 when missing", async () => {
+		const buf = await makeBuffer({
+			Cours: [
+				["code", "name", "teachingUnitCode", "credits", "coefficient"],
+				["", "", "", "", ""],
+				["ALGO1", "Algorithmique", "UE-ALGO", 3, ""],
+			],
+		});
+		const result = await parseAcademicStructure(buf);
+		expect(result.cours[0].coefficient).toBe(1);
+	});
+});
+
+describe("parsePeople", () => {
+	it("parses valid students", async () => {
+		const buf = await makeBuffer({
+			Étudiants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"nationality",
+					"registrationNumber",
+					"classCode",
+					"academicYearCode",
+				],
+				["", "", "", "", "", "", "", "", "", ""],
+				[
+					"Jean",
+					"Dupont",
+					"jean@ex.com",
+					"2002-01-01",
+					"H",
+					"",
+					"CM",
+					"ETU-001",
+					"SIN-BTS1",
+					"AY-2026",
+				],
+			],
+		});
+		const result = await parsePeople(buf);
+		expect(result.students).toHaveLength(1);
+		expect(result.students[0].email).toBe("jean@ex.com");
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it("errors on invalid email", async () => {
+		const buf = await makeBuffer({
+			Étudiants: [
+				["firstName", "lastName", "email"],
+				["", "", ""],
+				["Jean", "Dupont", "not-an-email"],
+			],
+		});
+		const result = await parsePeople(buf);
+		expect(result.errors.some((e) => e.col === "email")).toBe(true);
+	});
+
+	it("warns when classCode given without academicYearCode", async () => {
+		const buf = await makeBuffer({
+			Étudiants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"nationality",
+					"registrationNumber",
+					"classCode",
+					"academicYearCode",
+				],
+				["", "", "", "", "", "", "", "", "", ""],
+				["Jean", "Dupont", "jean@ex.com", "", "", "", "", "", "SIN-BTS1", ""],
+			],
+		});
+		const result = await parsePeople(buf);
+		expect(result.warnings.some((w) => w.col === "academicYearCode")).toBe(
+			true,
+		);
+		expect(result.students[0].classCode).toBeUndefined();
+	});
+
+	it("parses valid teachers", async () => {
+		const buf = await makeBuffer({
+			Enseignants: [
+				[
+					"firstName",
+					"lastName",
+					"email",
+					"dateOfBirth",
+					"gender",
+					"phone",
+					"specialty",
+				],
+				["", "", "", "", "", "", ""],
+				[
+					"Marie",
+					"Curie",
+					"m.curie@example.com",
+					"1975-11-07",
+					"F",
+					"",
+					"Math",
+				],
+			],
+		});
+		const result = await parsePeople(buf);
+		expect(result.teachers).toHaveLength(1);
+		expect(result.teachers[0].specialty).toBe("Math");
+	});
+});
+
+describe("parseEnrollments", () => {
+	it("parses valid enrollment rows", async () => {
+		const buf = await makeBuffer({
+			Inscriptions: [
+				[
+					"registrationNumber",
+					"classCode",
+					"academicYearCode",
+					"admissionType",
+				],
+				["", "", "", ""],
+				["ETU-001", "SIN-BTS1", "AY-2026", "normal"],
+			],
+		});
+		const { rows, errors } = await parseEnrollments(buf);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].classCode).toBe("SIN-BTS1");
+		expect(errors).toHaveLength(0);
+	});
+
+	it("errors on missing registrationNumber", async () => {
+		const buf = await makeBuffer({
+			Inscriptions: [
+				["registrationNumber", "classCode", "academicYearCode"],
+				["", "", ""],
+				["", "SIN-BTS1", "AY-2026"],
+			],
+		});
+		const { errors } = await parseEnrollments(buf);
+		expect(errors.some((e) => e.col === "registrationNumber")).toBe(true);
+	});
+
+	it("warns on unknown admissionType and defaults to normal", async () => {
+		const buf = await makeBuffer({
+			Inscriptions: [
+				[
+					"registrationNumber",
+					"classCode",
+					"academicYearCode",
+					"admissionType",
+				],
+				["", "", "", ""],
+				["ETU-001", "SIN-BTS1", "AY-2026", "invalide"],
+			],
+		});
+		const { rows, warnings } = await parseEnrollments(buf);
+		expect(warnings.some((w) => w.col === "admissionType")).toBe(true);
+		expect(rows[0].admissionType).toBe("normal");
+	});
+});
+
+describe("parseGradesBulk", () => {
+	it("parses valid grade rows", async () => {
+		const buf = await makeBuffer({
+			Notes: [
+				["examCode", "registrationNumber", "score"],
+				["", "", ""],
+				["CC-ALGO1", "ETU-001", 14.5],
+			],
+		});
+		const { rows, errors } = await parseGradesBulk(buf);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].score).toBe(14.5);
+		expect(errors).toHaveLength(0);
+	});
+
+	it("errors on non-numeric score", async () => {
+		const buf = await makeBuffer({
+			Notes: [
+				["examCode", "registrationNumber", "score"],
+				["", "", ""],
+				["CC-ALGO1", "ETU-001", "abc"],
+			],
+		});
+		const { errors } = await parseGradesBulk(buf);
+		expect(errors.some((e) => e.col === "score")).toBe(true);
+	});
+
+	it("warns on score out of range but keeps value", async () => {
+		const buf = await makeBuffer({
+			Notes: [
+				["examCode", "registrationNumber", "score"],
+				["", "", ""],
+				["CC-ALGO1", "ETU-001", 25],
+			],
+		});
+		const { rows, warnings } = await parseGradesBulk(buf);
+		expect(rows[0].score).toBe(25);
+		expect(warnings.some((w) => w.col === "score")).toBe(true);
+	});
+});

--- a/apps/server/src/modules/data-import/data-import.router.ts
+++ b/apps/server/src/modules/data-import/data-import.router.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { adminProcedure, router } from "@/lib/trpc";
+
+const TEMPLATE_TYPES = [
+	"academic-structure",
+	"people",
+	"enrollments",
+	"grades-bulk",
+] as const;
+
+export const dataImportRouter = router({
+	getTemplateUrl: adminProcedure
+		.input(z.object({ type: z.enum(TEMPLATE_TYPES) }))
+		.query(({ input }) => {
+			const base = process.env.SERVER_PUBLIC_URL ?? "";
+			return { url: `${base}/api/import/template/${input.type}` };
+		}),
+});

--- a/apps/server/src/modules/data-import/import-file-storage.ts
+++ b/apps/server/src/modules/data-import/import-file-storage.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const importRoot = process.env.STORAGE_LOCAL_ROOT
+	? path.join(process.env.STORAGE_LOCAL_ROOT, "imports")
+	: "./storage/uploads/imports";
+
+async function ensureDir() {
+	await mkdir(importRoot, { recursive: true });
+}
+
+export async function saveImportFile(
+	buffer: Buffer,
+	ext: string,
+): Promise<string> {
+	await ensureDir();
+	const fileId = `${randomUUID()}${ext}`;
+	await writeFile(path.join(importRoot, fileId), buffer);
+	return fileId;
+}
+
+export async function readImportFile(fileId: string): Promise<Buffer> {
+	const safeName = path.basename(fileId);
+	return readFile(path.join(importRoot, safeName));
+}
+
+export async function deleteImportFile(fileId: string): Promise<void> {
+	try {
+		await unlink(path.join(importRoot, path.basename(fileId)));
+	} catch {
+		// ignore missing file
+	}
+}

--- a/apps/server/src/modules/data-import/index.ts
+++ b/apps/server/src/modules/data-import/index.ts
@@ -1,0 +1,1 @@
+export { dataImportRouter } from "./data-import.router";

--- a/apps/server/src/modules/data-import/parsers/academic-structure.parser.ts
+++ b/apps/server/src/modules/data-import/parsers/academic-structure.parser.ts
@@ -1,0 +1,178 @@
+import ExcelJS from "exceljs";
+
+export type ParseError = { row: number; col?: string; message: string };
+export type ParseWarning = { row: number; col?: string; message: string };
+
+export type ProgrammeRow = {
+	code: string;
+	nameFr: string;
+	nameEn?: string;
+	studyCycleCode: string;
+	departmentCode?: string;
+	durationYears?: number;
+	totalCredits?: number;
+};
+export type CoursRow = {
+	code: string;
+	name: string;
+	teachingUnitCode: string;
+	credits?: number;
+	coefficient?: number;
+};
+export type ClasseRow = {
+	code: string;
+	name: string;
+	programCode: string;
+	programOptionCode?: string;
+	cycleLevelCode?: string;
+	semesterCode?: string;
+	academicYearCode: string;
+};
+export type AcademicStructureRows = {
+	programmes: ProgrammeRow[];
+	cours: CoursRow[];
+	classes: ClasseRow[];
+	errors: ParseError[];
+	warnings: ParseWarning[];
+};
+
+function cell(row: ExcelJS.Row, col: number): string {
+	const v = row.getCell(col).value;
+	return v == null ? "" : String(v).trim();
+}
+function num(row: ExcelJS.Row, col: number): number | undefined {
+	const v = row.getCell(col).value;
+	const n = Number(v);
+	return Number.isNaN(n) || v == null || v === "" ? undefined : n;
+}
+
+export async function parseAcademicStructure(
+	buffer: Buffer | Uint8Array,
+): Promise<AcademicStructureRows> {
+	const wb = new ExcelJS.Workbook();
+	// ExcelJS defines its own Buffer interface (extends ArrayBuffer) which is
+	// incompatible with Node.js Buffer<ArrayBufferLike> at the type level only.
+	// Runtime accepts Node.js Buffer just fine.
+	// biome-ignore lint/suspicious/noExplicitAny: ExcelJS Buffer type mismatch
+	await wb.xlsx.load(buffer as any);
+
+	const errors: ParseError[] = [];
+	const warnings: ParseWarning[] = [];
+	const programmes: ProgrammeRow[] = [];
+	const cours: CoursRow[] = [];
+	const classes: ClasseRow[] = [];
+
+	// Sheet: Programmes — skip row 1 (header) and row 2 (example)
+	const wsProg = wb.getWorksheet("Programmes");
+	if (wsProg) {
+		wsProg.eachRow((row, rowNum) => {
+			if (rowNum <= 2) return;
+			const code = cell(row, 1);
+			const nameFr = cell(row, 2);
+			const studyCycleCode = cell(row, 4);
+			if (!code) {
+				errors.push({ row: rowNum, col: "code", message: "code requis" });
+				return;
+			}
+			if (!nameFr) {
+				errors.push({ row: rowNum, col: "nameFr", message: "nameFr requis" });
+				return;
+			}
+			if (!studyCycleCode) {
+				warnings.push({
+					row: rowNum,
+					col: "studyCycleCode",
+					message: "studyCycleCode manquant — ligne ignorée",
+				});
+				return;
+			}
+			programmes.push({
+				code,
+				nameFr,
+				nameEn: cell(row, 3) || undefined,
+				studyCycleCode,
+				departmentCode: cell(row, 5) || undefined,
+				durationYears: num(row, 6),
+				totalCredits: num(row, 7),
+			});
+		});
+	}
+
+	// Sheet: Cours
+	const wsCours = wb.getWorksheet("Cours");
+	if (wsCours) {
+		wsCours.eachRow((row, rowNum) => {
+			if (rowNum <= 2) return;
+			const code = cell(row, 1);
+			const name = cell(row, 2);
+			const teachingUnitCode = cell(row, 3);
+			if (!code) {
+				errors.push({ row: rowNum, col: "code", message: "code requis" });
+				return;
+			}
+			if (!name) {
+				errors.push({ row: rowNum, col: "name", message: "name requis" });
+				return;
+			}
+			if (!teachingUnitCode) {
+				warnings.push({
+					row: rowNum,
+					col: "teachingUnitCode",
+					message: "teachingUnitCode manquant",
+				});
+				return;
+			}
+			const coefficient = num(row, 5);
+			cours.push({
+				code,
+				name,
+				teachingUnitCode,
+				credits: num(row, 4),
+				coefficient: coefficient == null ? 1 : coefficient,
+			});
+		});
+	}
+
+	// Sheet: Classes
+	const wsClasses = wb.getWorksheet("Classes");
+	if (wsClasses) {
+		wsClasses.eachRow((row, rowNum) => {
+			if (rowNum <= 2) return;
+			const code = cell(row, 1);
+			const name = cell(row, 2);
+			const programCode = cell(row, 3);
+			const academicYearCode = cell(row, 7);
+			if (!code) {
+				errors.push({ row: rowNum, col: "code", message: "code requis" });
+				return;
+			}
+			if (!programCode) {
+				errors.push({
+					row: rowNum,
+					col: "programCode",
+					message: "programCode requis",
+				});
+				return;
+			}
+			if (!academicYearCode) {
+				errors.push({
+					row: rowNum,
+					col: "academicYearCode",
+					message: "academicYearCode requis",
+				});
+				return;
+			}
+			classes.push({
+				code,
+				name: name || code,
+				programCode,
+				programOptionCode: cell(row, 4) || undefined,
+				cycleLevelCode: cell(row, 5) || undefined,
+				semesterCode: cell(row, 6) || undefined,
+				academicYearCode,
+			});
+		});
+	}
+
+	return { programmes, cours, classes, errors, warnings };
+}

--- a/apps/server/src/modules/data-import/parsers/enrollments.parser.ts
+++ b/apps/server/src/modules/data-import/parsers/enrollments.parser.ts
@@ -1,0 +1,92 @@
+import ExcelJS from "exceljs";
+import type { ParseError, ParseWarning } from "./academic-structure.parser";
+
+export type EnrollmentRow = {
+	registrationNumber: string;
+	classCode: string;
+	academicYearCode: string;
+	admissionType?: string;
+	transferInstitution?: string;
+	transferCredits?: number;
+};
+
+const VALID_ADMISSION_TYPES = ["normal", "transfer", "direct"];
+
+function cell(row: ExcelJS.Row, col: number): string {
+	const v = row.getCell(col).value;
+	return v == null ? "" : String(v).trim();
+}
+
+export async function parseEnrollments(buffer: Buffer | Uint8Array): Promise<{
+	rows: EnrollmentRow[];
+	errors: ParseError[];
+	warnings: ParseWarning[];
+}> {
+	const wb = new ExcelJS.Workbook();
+	// biome-ignore lint/suspicious/noExplicitAny: ExcelJS Buffer type mismatch
+	await wb.xlsx.load(buffer as any);
+	const ws = wb.getWorksheet("Inscriptions") ?? wb.worksheets[0];
+	const errors: ParseError[] = [];
+	const warnings: ParseWarning[] = [];
+	const rows: EnrollmentRow[] = [];
+
+	if (!ws) {
+		return {
+			rows,
+			errors: [{ row: 0, message: "Aucune feuille trouvée" }],
+			warnings,
+		};
+	}
+
+	ws.eachRow((row, rowNum) => {
+		if (rowNum <= 2) return;
+		const registrationNumber = cell(row, 1);
+		const classCode = cell(row, 2);
+		const academicYearCode = cell(row, 3);
+		if (!registrationNumber) {
+			errors.push({
+				row: rowNum,
+				col: "registrationNumber",
+				message: "requis",
+			});
+			return;
+		}
+		if (!classCode) {
+			errors.push({ row: rowNum, col: "classCode", message: "requis" });
+			return;
+		}
+		if (!academicYearCode) {
+			errors.push({
+				row: rowNum,
+				col: "academicYearCode",
+				message: "requis",
+			});
+			return;
+		}
+		const admissionType = cell(row, 4) || "normal";
+		if (!VALID_ADMISSION_TYPES.includes(admissionType)) {
+			warnings.push({
+				row: rowNum,
+				col: "admissionType",
+				message: `valeur inconnue "${admissionType}" — "normal" utilisé`,
+			});
+		}
+		const creditsRaw = row.getCell(6).value;
+		const transferCredits =
+			creditsRaw == null || creditsRaw === "" ? undefined : Number(creditsRaw);
+		rows.push({
+			registrationNumber,
+			classCode,
+			academicYearCode,
+			admissionType: VALID_ADMISSION_TYPES.includes(admissionType)
+				? admissionType
+				: "normal",
+			transferInstitution: cell(row, 5) || undefined,
+			transferCredits: Number.isNaN(transferCredits)
+				? undefined
+				: transferCredits,
+		});
+	});
+
+	return { rows, errors, warnings };
+}

--- a/apps/server/src/modules/data-import/parsers/grades-bulk.parser.ts
+++ b/apps/server/src/modules/data-import/parsers/grades-bulk.parser.ts
@@ -1,0 +1,73 @@
+import ExcelJS from "exceljs";
+import type { ParseError, ParseWarning } from "./academic-structure.parser";
+
+export type GradeRow = {
+	examCode: string;
+	registrationNumber: string;
+	score: number;
+};
+
+function cell(row: ExcelJS.Row, col: number): string {
+	const v = row.getCell(col).value;
+	return v == null ? "" : String(v).trim();
+}
+
+export async function parseGradesBulk(buffer: Buffer | Uint8Array): Promise<{
+	rows: GradeRow[];
+	errors: ParseError[];
+	warnings: ParseWarning[];
+}> {
+	const wb = new ExcelJS.Workbook();
+	// biome-ignore lint/suspicious/noExplicitAny: ExcelJS Buffer type mismatch
+	await wb.xlsx.load(buffer as any);
+	const ws = wb.getWorksheet("Notes") ?? wb.worksheets[0];
+	const errors: ParseError[] = [];
+	const warnings: ParseWarning[] = [];
+	const rows: GradeRow[] = [];
+
+	if (!ws) {
+		return {
+			rows,
+			errors: [{ row: 0, message: "Feuille 'Notes' introuvable" }],
+			warnings,
+		};
+	}
+
+	ws.eachRow((row, rowNum) => {
+		if (rowNum <= 2) return;
+		const examCode = cell(row, 1);
+		const registrationNumber = cell(row, 2);
+		const scoreRaw = row.getCell(3).value;
+		if (!examCode) {
+			errors.push({ row: rowNum, col: "examCode", message: "requis" });
+			return;
+		}
+		if (!registrationNumber) {
+			errors.push({
+				row: rowNum,
+				col: "registrationNumber",
+				message: "requis",
+			});
+			return;
+		}
+		const score = Number(scoreRaw);
+		if (Number.isNaN(score)) {
+			errors.push({
+				row: rowNum,
+				col: "score",
+				message: `score invalide: "${scoreRaw}"`,
+			});
+			return;
+		}
+		if (score < 0 || score > 20) {
+			warnings.push({
+				row: rowNum,
+				col: "score",
+				message: `score ${score} hors plage [0,20] — valeur conservée`,
+			});
+		}
+		rows.push({ examCode, registrationNumber, score });
+	});
+
+	return { rows, errors, warnings };
+}

--- a/apps/server/src/modules/data-import/parsers/people.parser.ts
+++ b/apps/server/src/modules/data-import/parsers/people.parser.ts
@@ -1,0 +1,135 @@
+import ExcelJS from "exceljs";
+import type { ParseError, ParseWarning } from "./academic-structure.parser";
+
+export type StudentRow = {
+	firstName: string;
+	lastName: string;
+	email: string;
+	dateOfBirth?: string;
+	gender?: string;
+	phone?: string;
+	nationality?: string;
+	registrationNumber?: string;
+	classCode?: string;
+	academicYearCode?: string;
+};
+export type TeacherRow = {
+	firstName: string;
+	lastName: string;
+	email: string;
+	dateOfBirth?: string;
+	gender?: string;
+	phone?: string;
+	specialty?: string;
+};
+export type PeopleRows = {
+	students: StudentRow[];
+	teachers: TeacherRow[];
+	errors: ParseError[];
+	warnings: ParseWarning[];
+};
+
+function cell(row: ExcelJS.Row, col: number): string {
+	const v = row.getCell(col).value;
+	return v == null ? "" : String(v).trim();
+}
+
+function isValidEmail(s: string): boolean {
+	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+}
+
+export async function parsePeople(
+	buffer: Buffer | Uint8Array,
+): Promise<PeopleRows> {
+	const wb = new ExcelJS.Workbook();
+	// biome-ignore lint/suspicious/noExplicitAny: ExcelJS Buffer type mismatch
+	await wb.xlsx.load(buffer as any);
+	const errors: ParseError[] = [];
+	const warnings: ParseWarning[] = [];
+	const students: StudentRow[] = [];
+	const teachers: TeacherRow[] = [];
+
+	const wsEtu = wb.getWorksheet("Étudiants");
+	if (wsEtu) {
+		wsEtu.eachRow((row, rowNum) => {
+			if (rowNum <= 2) return;
+			const firstName = cell(row, 1);
+			const lastName = cell(row, 2);
+			const email = cell(row, 3);
+			if (!firstName || !lastName) {
+				errors.push({
+					row: rowNum,
+					message: "firstName et lastName requis",
+				});
+				return;
+			}
+			if (!email || !isValidEmail(email)) {
+				errors.push({
+					row: rowNum,
+					col: "email",
+					message: `email invalide: "${email}"`,
+				});
+				return;
+			}
+			const classCode = cell(row, 9) || undefined;
+			const academicYearCode = cell(row, 10) || undefined;
+			if (classCode && !academicYearCode) {
+				warnings.push({
+					row: rowNum,
+					col: "academicYearCode",
+					message:
+						"classCode fourni sans academicYearCode — inscription ignorée",
+				});
+			}
+			const hasEnrollmentInfo = classCode && academicYearCode;
+			students.push({
+				firstName,
+				lastName,
+				email,
+				dateOfBirth: cell(row, 4) || undefined,
+				gender: cell(row, 5) || undefined,
+				phone: cell(row, 6) || undefined,
+				nationality: cell(row, 7) || undefined,
+				registrationNumber: cell(row, 8) || undefined,
+				classCode: hasEnrollmentInfo ? classCode : undefined,
+				academicYearCode: hasEnrollmentInfo ? academicYearCode : undefined,
+			});
+		});
+	}
+
+	const wsEnseig = wb.getWorksheet("Enseignants");
+	if (wsEnseig) {
+		wsEnseig.eachRow((row, rowNum) => {
+			if (rowNum <= 2) return;
+			const firstName = cell(row, 1);
+			const lastName = cell(row, 2);
+			const email = cell(row, 3);
+			if (!firstName || !lastName) {
+				errors.push({
+					row: rowNum,
+					message: "firstName et lastName requis",
+				});
+				return;
+			}
+			if (!email || !isValidEmail(email)) {
+				errors.push({
+					row: rowNum,
+					col: "email",
+					message: `email invalide: "${email}"`,
+				});
+				return;
+			}
+			teachers.push({
+				firstName,
+				lastName,
+				email,
+				dateOfBirth: cell(row, 4) || undefined,
+				gender: cell(row, 5) || undefined,
+				phone: cell(row, 6) || undefined,
+				specialty: cell(row, 7) || undefined,
+			});
+		});
+	}
+
+	return { students, teachers, errors, warnings };
+}

--- a/apps/server/src/modules/data-import/template-generator.ts
+++ b/apps/server/src/modules/data-import/template-generator.ts
@@ -1,0 +1,238 @@
+import ExcelJS from "exceljs";
+
+export type ImportTemplateType =
+	| "academic-structure"
+	| "people"
+	| "enrollments"
+	| "grades-bulk";
+
+const HEADER_FILL: ExcelJS.Fill = {
+	type: "pattern",
+	pattern: "solid",
+	fgColor: { argb: "FF1E40AF" },
+};
+const HEADER_FONT: Partial<ExcelJS.Font> = {
+	bold: true,
+	color: { argb: "FFFFFFFF" },
+};
+const EXAMPLE_FONT: Partial<ExcelJS.Font> = {
+	italic: true,
+	color: { argb: "FF9CA3AF" },
+};
+
+function addHeaderRow(ws: ExcelJS.Worksheet, columns: string[]) {
+	ws.columns = columns.map((c) => ({
+		header: c,
+		key: c,
+		width: Math.max(c.length + 4, 18),
+	}));
+	const headerRow = ws.getRow(1);
+	headerRow.eachCell((cell) => {
+		cell.fill = HEADER_FILL;
+		cell.font = HEADER_FONT;
+	});
+}
+
+function addExampleRow(ws: ExcelJS.Worksheet, values: (string | number)[]) {
+	const row = ws.addRow(values);
+	row.eachCell((cell) => {
+		cell.font = EXAMPLE_FONT;
+	});
+}
+
+function addEnumValidation(
+	ws: ExcelJS.Worksheet,
+	col: number,
+	startRow: number,
+	values: string[],
+) {
+	for (let r = startRow; r <= startRow + 500; r++) {
+		ws.getCell(r, col).dataValidation = {
+			type: "list",
+			allowBlank: true,
+			formulae: [`"${values.join(",")}"`],
+		};
+	}
+}
+
+async function buildAcademicStructureTemplate(): Promise<Buffer> {
+	const wb = new ExcelJS.Workbook();
+
+	const wsProg = wb.addWorksheet("Programmes");
+	addHeaderRow(wsProg, [
+		"code",
+		"nameFr",
+		"nameEn",
+		"studyCycleCode",
+		"departmentCode",
+		"durationYears",
+		"totalCredits",
+	]);
+	addExampleRow(wsProg, [
+		"SIN",
+		"Sciences Informatiques",
+		"Computer Science",
+		"BTS",
+		"GINF",
+		2,
+		120,
+	]);
+	wsProg.getCell("A2").note =
+		'Formule suggérée: =UPPER(LEFT(SUBSTITUTE(B2," ",""),4))';
+
+	const wsCours = wb.addWorksheet("Cours");
+	addHeaderRow(wsCours, [
+		"code",
+		"name",
+		"teachingUnitCode",
+		"credits",
+		"coefficient",
+	]);
+	addExampleRow(wsCours, ["ALGO1", "Algorithmique", "UE-ALGO", 3, 2]);
+
+	const wsClasses = wb.addWorksheet("Classes");
+	addHeaderRow(wsClasses, [
+		"code",
+		"name",
+		"programCode",
+		"programOptionCode",
+		"cycleLevelCode",
+		"semesterCode",
+		"academicYearName",
+	]);
+	addExampleRow(wsClasses, [
+		"SIN-BTS1-2026",
+		"SIN BTS1 2025-2026",
+		"SIN",
+		"GEN",
+		"BTS1",
+		"S1",
+		"2025-2026",
+	]);
+
+	const wsRef = wb.addWorksheet("Références");
+	wsRef.state = "hidden";
+	wsRef.addRow([
+		"[Codes académiques de votre institution — rempli dynamiquement]",
+	]);
+
+	const { buffer } = (await wb.xlsx.writeBuffer()) as unknown as {
+		buffer: Buffer;
+	};
+	return buffer;
+}
+
+async function buildPeopleTemplate(): Promise<Buffer> {
+	const wb = new ExcelJS.Workbook();
+
+	const wsEtu = wb.addWorksheet("Étudiants");
+	addHeaderRow(wsEtu, [
+		"firstName",
+		"lastName",
+		"email",
+		"dateOfBirth",
+		"gender",
+		"phone",
+		"nationality",
+		"registrationNumber",
+		"classCode",
+		"academicYearName",
+	]);
+	addExampleRow(wsEtu, [
+		"Jean",
+		"Dupont",
+		"jean.dupont@example.com",
+		"2002-03-15",
+		"H",
+		"+237600000001",
+		"Camerounaise",
+		"ETU-2026-001",
+		"SIN-BTS1-2026",
+		"2025-2026",
+	]);
+	addEnumValidation(wsEtu, 5, 3, ["H", "F"]);
+
+	const wsEnseig = wb.addWorksheet("Enseignants");
+	addHeaderRow(wsEnseig, [
+		"firstName",
+		"lastName",
+		"email",
+		"dateOfBirth",
+		"gender",
+		"phone",
+		"specialty",
+	]);
+	addExampleRow(wsEnseig, [
+		"Marie",
+		"Curie",
+		"m.curie@example.com",
+		"1975-11-07",
+		"F",
+		"+237600000002",
+		"Mathématiques",
+	]);
+	addEnumValidation(wsEnseig, 5, 3, ["H", "F"]);
+
+	const wsRef = wb.addWorksheet("Références");
+	wsRef.state = "hidden";
+	wsRef.addRow(["Codes classes et années académiques de votre institution"]);
+
+	const { buffer } = (await wb.xlsx.writeBuffer()) as unknown as {
+		buffer: Buffer;
+	};
+	return buffer;
+}
+
+async function buildEnrollmentsTemplate(): Promise<Buffer> {
+	const wb = new ExcelJS.Workbook();
+	const ws = wb.addWorksheet("Inscriptions");
+	addHeaderRow(ws, [
+		"registrationNumber",
+		"classCode",
+		"academicYearName",
+		"admissionType",
+		"transferInstitution",
+		"transferCredits",
+	]);
+	addExampleRow(ws, [
+		"ETU-2026-001",
+		"SIN-BTS1-2026",
+		"2025-2026",
+		"normal",
+		"",
+		"",
+	]);
+	addEnumValidation(ws, 4, 3, ["normal", "transfer", "direct"]);
+
+	const { buffer } = (await wb.xlsx.writeBuffer()) as unknown as {
+		buffer: Buffer;
+	};
+	return buffer;
+}
+
+async function buildGradesBulkTemplate(): Promise<Buffer> {
+	const wb = new ExcelJS.Workbook();
+	const ws = wb.addWorksheet("Notes");
+	addHeaderRow(ws, ["examName", "registrationNumber", "score"]);
+	addExampleRow(ws, ["CC Algorithmique BTS1-S1", "ETU-2026-001", 14.5]);
+
+	const { buffer } = (await wb.xlsx.writeBuffer()) as unknown as {
+		buffer: Buffer;
+	};
+	return buffer;
+}
+
+export async function generateImportTemplate(
+	type: ImportTemplateType,
+): Promise<Buffer> {
+	switch (type) {
+		case "academic-structure":
+			return buildAcademicStructureTemplate();
+		case "people":
+			return buildPeopleTemplate();
+		case "enrollments":
+			return buildEnrollmentsTemplate();
+		case "grades-bulk":
+			return buildGradesBulkTemplate();
+	}
+}

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -23,6 +23,7 @@ import { classCoursesRouter } from "../modules/class-courses";
 import { classesRouter } from "../modules/classes";
 import { coursesRouter } from "../modules/courses";
 import { cycleLevelsRouter } from "../modules/cycle-levels";
+import { dataImportRouter } from "../modules/data-import";
 import { enrollmentsRouter } from "../modules/enrollments";
 import { examTypesRouter } from "../modules/exam-types";
 import { examsRouter } from "../modules/exams";
@@ -82,6 +83,7 @@ export const appRouter = router({
 	exportTemplates: exportTemplatesRouter,
 	users: usersRouter,
 	workflows: workflowsRouter,
+	dataImport: dataImportRouter,
 	notifications: notificationsRouter,
 	batchJobs: batchJobsRouter,
 	deliberations: deliberationsRouter,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -75,6 +75,7 @@ import GradeScaleSettings from "./pages/admin/GradeScaleSettings";
 import GraduatedStudents from "./pages/admin/GraduatedStudents";
 import InstitutionHub from "./pages/admin/InstitutionHub";
 import InstitutionSettings from "./pages/admin/InstitutionSettings";
+import DataImportHub from "./pages/admin/import/DataImportHub";
 import MonitoringDashboard from "./pages/admin/MonitoringDashboard";
 import NotificationsCenter from "./pages/admin/NotificationsCenter";
 import ProgramsHub from "./pages/admin/ProgramsHub";
@@ -290,6 +291,7 @@ function App() {
 						<Route path="monitoring" element={<MonitoringDashboard />} />
 						<Route path="batch-jobs" element={<BatchJobsDashboard />} />
 						<Route path="batch-jobs/:jobId" element={<BatchJobDetail />} />
+						<Route path="import" element={<DataImportHub />} />
 						<Route path="statistics" element={<StatisticsHub />} />
 						<Route path="fee-clearance">
 							<Route element={<FeeClearanceHub />}>

--- a/apps/web/src/components/navigation/Sidebar.tsx
+++ b/apps/web/src/components/navigation/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 	FileCog,
 	FileSpreadsheet,
 	FileText,
+	FileUp,
 	Gavel,
 	GraduationCap,
 	Heart,
@@ -210,6 +211,11 @@ const Sidebar: React.FC = () => {
 						icon: <PlayCircle className={IC} />,
 						labelKey: "navigation.sidebar.admin.batchJobs",
 						badge: "new" as NavBadgeType,
+					},
+					{
+						to: "/admin/import",
+						icon: <FileUp className={IC} />,
+						labelKey: "navigation.sidebar.admin.dataImport",
 					},
 					{
 						to: "/admin/fee-clearance",

--- a/apps/web/src/i18n/locales/en/translation.json
+++ b/apps/web/src/i18n/locales/en/translation.json
@@ -1211,6 +1211,7 @@
         "monitoring": "Monitoring",
         "notifications": "Notifications",
         "batchJobs": "Batch Jobs",
+        "dataImport": "Data Import",
         "feeClearance": "Fee Clearance",
         "statistics": "Statistics",
         "students": "Students",
@@ -4447,6 +4448,44 @@
         "success": "Copy started successfully",
         "noTargetYear": "First select a target year in the filters"
       }
+    },
+    "dataImport": {
+      "title": "Data Import",
+      "subtitle": "Import your institution data from Excel or CSV",
+      "tabs": {
+        "structure": "Academic Structure",
+        "people": "People",
+        "enrollments": "Enrollments",
+        "grades": "Grades"
+      },
+      "downloadTemplate": "Download template",
+      "uploadZone": "Drag your file here or click to select",
+      "uploadZoneAccept": "Excel (.xlsx) or CSV (.csv) · max 10 MB",
+      "preview": {
+        "valid": "{{count}} valid row(s)",
+        "skipped": "{{count}} skipped (already exist)",
+        "errors": "{{count}} error(s)",
+        "warnings": "{{count}} warning(s)",
+        "row": "Row",
+        "column": "Column",
+        "message": "Message",
+        "noErrors": "No errors"
+      },
+      "confirm": "Run import",
+      "uploading": "Uploading…",
+      "previewing": "Analysing file…",
+      "noFile": "No file selected",
+      "errorBlocker": "Fix errors before confirming",
+      "toast": {
+        "uploadOk": "File received",
+        "importStarted": "Import started"
+      },
+      "prereqHint": {
+        "people": "Import academic structure first if classes don't exist yet.",
+        "enrollments": "Students and classes must exist before importing enrollments.",
+        "grades": "Exams must exist before importing grades."
+      },
+      "newFile": "New file"
     }
   },
   "dean": {

--- a/apps/web/src/i18n/locales/fr/translation.json
+++ b/apps/web/src/i18n/locales/fr/translation.json
@@ -202,6 +202,7 @@
         "monitoring": "Monitoring",
         "notifications": "Notifications",
         "batchJobs": "Traitements par lots",
+        "dataImport": "Import de données",
         "feeClearance": "Quitus / Frais",
         "statistics": "Statistiques",
         "students": "Etudiants",
@@ -3435,6 +3436,44 @@
         "success": "Copie lancée avec succès",
         "noTargetYear": "Sélectionnez d'abord une année cible dans les filtres"
       }
+    },
+    "dataImport": {
+      "title": "Import de données",
+      "subtitle": "Importez vos données depuis un fichier Excel ou CSV",
+      "tabs": {
+        "structure": "Structure académique",
+        "people": "Personnes",
+        "enrollments": "Inscriptions",
+        "grades": "Notes"
+      },
+      "downloadTemplate": "Télécharger le modèle",
+      "uploadZone": "Glissez votre fichier ici ou cliquez pour sélectionner",
+      "uploadZoneAccept": "Excel (.xlsx) ou CSV (.csv) · max 10 Mo",
+      "preview": {
+        "valid": "{{count}} ligne(s) valide(s)",
+        "skipped": "{{count}} ligne(s) ignorée(s) (déjà existantes)",
+        "errors": "{{count}} erreur(s)",
+        "warnings": "{{count}} avertissement(s)",
+        "row": "Ligne",
+        "column": "Colonne",
+        "message": "Message",
+        "noErrors": "Aucune erreur"
+      },
+      "confirm": "Lancer l'import",
+      "uploading": "Téléversement…",
+      "previewing": "Analyse du fichier…",
+      "noFile": "Aucun fichier sélectionné",
+      "errorBlocker": "Corrigez les erreurs avant de confirmer l'import",
+      "toast": {
+        "uploadOk": "Fichier reçu",
+        "importStarted": "Import lancé"
+      },
+      "prereqHint": {
+        "people": "Importez d'abord la structure académique si les classes n'existent pas encore.",
+        "enrollments": "Les étudiants et les classes doivent exister avant les inscriptions.",
+        "grades": "Les examens doivent exister avant d'importer les notes."
+      },
+      "newFile": "Nouveau fichier"
     }
   },
   "teacher": {

--- a/apps/web/src/pages/admin/import/DataImportHub.tsx
+++ b/apps/web/src/pages/admin/import/DataImportHub.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ImportSection } from "./ImportSection";
+
+export default function DataImportHub() {
+	const { t } = useTranslation();
+
+	return (
+		<div className="container max-w-3xl py-8">
+			<div className="mb-6">
+				<h1 className="font-bold text-2xl">{t("admin.dataImport.title")}</h1>
+				<p className="mt-1 text-muted-foreground">
+					{t("admin.dataImport.subtitle")}
+				</p>
+			</div>
+
+			<Tabs defaultValue="structure">
+				<TabsList className="mb-6 grid w-full grid-cols-4">
+					<TabsTrigger value="structure">
+						{t("admin.dataImport.tabs.structure")}
+					</TabsTrigger>
+					<TabsTrigger value="people">
+						{t("admin.dataImport.tabs.people")}
+					</TabsTrigger>
+					<TabsTrigger value="enrollments">
+						{t("admin.dataImport.tabs.enrollments")}
+					</TabsTrigger>
+					<TabsTrigger value="grades">
+						{t("admin.dataImport.tabs.grades")}
+					</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="structure">
+					<ImportSection type="academic-structure" />
+				</TabsContent>
+				<TabsContent value="people">
+					<ImportSection
+						type="people"
+						prereqHint={t("admin.dataImport.prereqHint.people")}
+					/>
+				</TabsContent>
+				<TabsContent value="enrollments">
+					<ImportSection
+						type="enrollments"
+						prereqHint={t("admin.dataImport.prereqHint.enrollments")}
+					/>
+				</TabsContent>
+				<TabsContent value="grades">
+					<ImportSection
+						type="grades-bulk"
+						prereqHint={t("admin.dataImport.prereqHint.grades")}
+					/>
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}

--- a/apps/web/src/pages/admin/import/ImportSection.tsx
+++ b/apps/web/src/pages/admin/import/ImportSection.tsx
@@ -1,0 +1,253 @@
+import { useMutation } from "@tanstack/react-query";
+import { Download, Upload } from "lucide-react";
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import { Button } from "@/components/ui/button";
+import { getServerUrl } from "@/lib/runtime-config";
+import { toast } from "@/lib/toast";
+import { trpcClient } from "@/utils/trpc";
+import { PreviewTable } from "./PreviewTable";
+
+type ImportType =
+	| "academic-structure"
+	| "people"
+	| "enrollments"
+	| "grades-bulk";
+
+interface Props {
+	type: ImportType;
+	prereqHint?: string;
+}
+
+type PreviewSummary = {
+	errors?: Array<{ row: number; col?: string; message: string }>;
+	warnings?: Array<{ row: number; col?: string; message: string }>;
+	[key: string]: unknown;
+};
+
+const batchJobType = {
+	"academic-structure": "import.academicStructure",
+	people: "import.people",
+	enrollments: "import.enrollments",
+	"grades-bulk": "import.gradesBulk",
+} as const;
+
+export function ImportSection({ type, prereqHint }: Props) {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [fileId, setFileId] = useState<string | null>(null);
+	const [fileName, setFileName] = useState<string | null>(null);
+	const [jobId, setJobId] = useState<string | null>(null);
+	const [previewSummary, setPreviewSummary] = useState<PreviewSummary | null>(
+		null,
+	);
+
+	const templateUrl = `${getServerUrl()}/api/import/template/${type}`;
+
+	const uploadMutation = useMutation({
+		mutationFn: async (file: File) => {
+			const form = new FormData();
+			form.append("file", file);
+			const res = await fetch(`${getServerUrl()}/api/import/upload`, {
+				method: "POST",
+				body: form,
+				credentials: "include",
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: "Upload failed" }));
+				throw new Error((err as { error?: string }).error ?? "Upload failed");
+			}
+			return res.json() as Promise<{ fileId: string }>;
+		},
+		onSuccess: (data) => {
+			setFileId(data.fileId);
+			toast.success(t("admin.dataImport.toast.uploadOk"));
+			previewMutation.mutate(data.fileId);
+		},
+		onError: (err) => toast.error((err as Error).message),
+	});
+
+	const previewMutation = useMutation({
+		mutationFn: (fId: string) =>
+			trpcClient.batchJobs.preview.mutate({
+				type: batchJobType[type],
+				params: { fileId: fId },
+			}),
+		onSuccess: (data) => {
+			setJobId(data.id);
+			setPreviewSummary((data.previewResult ?? {}) as PreviewSummary);
+		},
+		onError: (err) => toast.error((err as Error).message),
+	});
+
+	const runMutation = useMutation({
+		mutationFn: () => trpcClient.batchJobs.run.mutate({ jobId: jobId! }),
+		onSuccess: () => {
+			toast.success(t("admin.dataImport.toast.importStarted"));
+			navigate(`/admin/batch-jobs/${jobId}`);
+		},
+		onError: (err) => toast.error((err as Error).message),
+	});
+
+	function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+		const file = e.target.files?.[0];
+		if (!file) return;
+		setFileName(file.name);
+		setFileId(null);
+		setJobId(null);
+		setPreviewSummary(null);
+		uploadMutation.mutate(file);
+	}
+
+	function handleDrop(e: React.DragEvent) {
+		e.preventDefault();
+		const file = e.dataTransfer.files[0];
+		if (!file) return;
+		setFileName(file.name);
+		setFileId(null);
+		setJobId(null);
+		setPreviewSummary(null);
+		uploadMutation.mutate(file);
+	}
+
+	function reset() {
+		setFileId(null);
+		setFileName(null);
+		setJobId(null);
+		setPreviewSummary(null);
+		if (inputRef.current) inputRef.current.value = "";
+	}
+
+	const errors = previewSummary?.errors ?? [];
+	const warnings = previewSummary?.warnings ?? [];
+	const hasBlockingErrors = errors.length > 0;
+	const isLoading = uploadMutation.isPending || previewMutation.isPending;
+
+	const summaryEntries = previewSummary
+		? Object.entries(previewSummary).filter(
+				([k]) => k !== "errors" && k !== "warnings",
+			)
+		: [];
+
+	return (
+		<div className="space-y-5">
+			{prereqHint && (
+				<p className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-blue-800 text-sm dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300">
+					{prereqHint}
+				</p>
+			)}
+
+			{/* Template download */}
+			<div className="flex items-center justify-between rounded-lg border p-4">
+				<div>
+					<p className="font-medium text-sm">Modèle Excel</p>
+					<p className="text-muted-foreground text-xs">
+						{t("admin.dataImport.uploadZoneAccept")}
+					</p>
+				</div>
+				<Button variant="outline" size="sm" asChild>
+					<a href={templateUrl} download>
+						<Download className="mr-2 h-4 w-4" />
+						{t("admin.dataImport.downloadTemplate")}
+					</a>
+				</Button>
+			</div>
+
+			{/* Drop zone */}
+			<div
+				className="cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors hover:border-primary hover:bg-accent/30"
+				onClick={() => inputRef.current?.click()}
+				onKeyDown={(e) => e.key === "Enter" && inputRef.current?.click()}
+				role="button"
+				tabIndex={0}
+				onDragOver={(e) => e.preventDefault()}
+				onDrop={handleDrop}
+			>
+				<Upload className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+				<p className="text-sm">
+					{fileName ? (
+						<span className="font-medium">{fileName}</span>
+					) : (
+						t("admin.dataImport.uploadZone")
+					)}
+				</p>
+				<p className="mt-1 text-muted-foreground text-xs">
+					{t("admin.dataImport.uploadZoneAccept")}
+				</p>
+				<input
+					ref={inputRef}
+					type="file"
+					accept=".xlsx,.csv"
+					className="hidden"
+					onChange={handleFileChange}
+				/>
+			</div>
+
+			{/* Loading */}
+			{isLoading && (
+				<p className="animate-pulse text-center text-muted-foreground text-sm">
+					{uploadMutation.isPending
+						? t("admin.dataImport.uploading")
+						: t("admin.dataImport.previewing")}
+				</p>
+			)}
+
+			{/* Preview results */}
+			{previewSummary && !isLoading && (
+				<div className="space-y-3">
+					{summaryEntries.length > 0 && (
+						<div className="flex flex-wrap gap-2">
+							{summaryEntries.map(([k, v]) => (
+								<span
+									key={k}
+									className="rounded-full border bg-muted px-3 py-0.5 text-xs"
+								>
+									{k}: <strong>{String(v)}</strong>
+								</span>
+							))}
+						</div>
+					)}
+					<PreviewTable
+						rows={errors}
+						label={t("admin.dataImport.preview.errors", {
+							count: errors.length,
+						})}
+						variant="error"
+					/>
+					<PreviewTable
+						rows={warnings}
+						label={t("admin.dataImport.preview.warnings", {
+							count: warnings.length,
+						})}
+						variant="warning"
+					/>
+					{!hasBlockingErrors && (
+						<p className="text-green-700 text-sm dark:text-green-400">
+							✓ {t("admin.dataImport.preview.noErrors")}
+						</p>
+					)}
+				</div>
+			)}
+
+			{/* Actions */}
+			{previewSummary && !isLoading && (
+				<div className="flex gap-2">
+					<Button variant="outline" onClick={reset} size="sm">
+						{t("admin.dataImport.newFile")}
+					</Button>
+					<Button
+						onClick={() => runMutation.mutate()}
+						disabled={hasBlockingErrors || runMutation.isPending || !jobId}
+						size="sm"
+					>
+						{hasBlockingErrors
+							? t("admin.dataImport.errorBlocker")
+							: t("admin.dataImport.confirm")}
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/pages/admin/import/PreviewTable.tsx
+++ b/apps/web/src/pages/admin/import/PreviewTable.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from "react-i18next";
+
+type PreviewRow = { row: number; col?: string; message: string };
+
+interface Props {
+	rows: PreviewRow[];
+	label: string;
+	variant?: "error" | "warning";
+}
+
+export function PreviewTable({ rows, label, variant = "error" }: Props) {
+	const { t } = useTranslation();
+	if (rows.length === 0) return null;
+	const color =
+		variant === "error"
+			? "text-red-700 bg-red-50 border-red-200 dark:text-red-300 dark:bg-red-950 dark:border-red-800"
+			: "text-yellow-800 bg-yellow-50 border-yellow-200 dark:text-yellow-300 dark:bg-yellow-950 dark:border-yellow-800";
+
+	return (
+		<div className={`rounded-md border p-3 ${color}`}>
+			<p className="mb-2 font-medium text-sm">{label}</p>
+			<div className="overflow-x-auto">
+				<table className="w-full text-xs">
+					<thead>
+						<tr className="border-current/20 border-b">
+							<th className="pr-4 pb-1 text-left font-medium">
+								{t("admin.dataImport.preview.row")}
+							</th>
+							<th className="pr-4 pb-1 text-left font-medium">
+								{t("admin.dataImport.preview.column")}
+							</th>
+							<th className="pb-1 text-left font-medium">
+								{t("admin.dataImport.preview.message")}
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{rows.map((r, i) => (
+							<tr key={i} className="border-current/10 border-b">
+								<td className="py-0.5 pr-4">{r.row}</td>
+								<td className="py-0.5 pr-4">{r.col ?? "—"}</td>
+								<td className="py-0.5">{r.message}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
… jobs

- REST endpoints: POST /api/import/upload, GET /api/import/template/:type
- 4 new batch job types: import.academicStructure, import.people, import.enrollments, import.gradesBulk
- Excel template generator (ExcelJS) with headers, example rows, dropdowns
- File parsers with error/warning collection (skip rows 1-2)
- dataImport tRPC router (getTemplateUrl)
- Frontend: DataImportHub page at /admin/import with 4 tabs, file upload,
  preview and confirm flow
- i18n keys moved to correct path admin.dataImport.* (FR + EN)
- Fix gender mapping: accept "H" (Homme) in addition to "M" → male
- 15 parser unit tests + 15 batch job integration tests